### PR TITLE
Add CWD as operator location

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -68,15 +68,36 @@ func getOperator(insDef op.InstanceDef, par *op.Operator, currDir string) (*op.O
 		return builtinOp, nil
 	}
 
-	defFilePath := path.Join(currDir, strings.Replace(insDef.Operator, ".", "/", -1)+".json")
+	relFilePath := strings.Replace(insDef.Operator, ".", "/", -1)+".json"
 
-	o, err := readOperator(insDef.Name, defFilePath, par)
+	if strings.HasPrefix(insDef.Operator, ".") {
+		defFilePath := path.Join(currDir, relFilePath)
+		o, err := readOperator(insDef.Name, defFilePath, par)
 
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
+
+		return o, nil
 	}
 
-	return o, nil
+	paths := []string{"."}
+
+	var err error
+	for _, p := range paths {
+		defFilePath := path.Join(p, relFilePath)
+
+		var o *op.Operator
+		o, err = readOperator(insDef.Name, defFilePath, par)
+
+		if err != nil {
+			continue
+		}
+
+		return o, nil
+	}
+
+	return nil, err
 }
 
 func parseConnection(connStr string, operator *op.Operator) (*op.Port, error) {

--- a/operator_test.go
+++ b/operator_test.go
@@ -75,6 +75,19 @@ func TestOperator_ReadOperator_NestedOperator_SubChild(t *testing.T) {
 	assertPortItems(t, []interface{}{"hallohallo", 4.0}, o.OutPort())
 }
 
+func TestOperator_ReadOperator_NestedOperator_Cwd(t *testing.T) {
+	o, err := ReadOperator("test_data/cwdOp.json")
+	assertNoError(t, err)
+
+	o.OutPort().Bufferize()
+	o.InPort().Push("hey")
+	o.InPort().Push(false)
+
+	o.Start()
+
+	assertPortItems(t, []interface{}{"hey", false}, o.OutPort())
+}
+
 func TestParseConnection__NilOperator(t *testing.T) {
 	p, err := parseConnection("test.in", nil)
 	assertError(t, err)

--- a/test_data/cwdOp.json
+++ b/test_data/cwdOp.json
@@ -1,0 +1,23 @@
+{
+  "name": "opr",
+  "in": {
+    "type": "number"
+  },
+  "out": {
+    "type": "number"
+  },
+  "operators": [
+    {
+      "operator": "test_data.voidOp",
+      "name": "void"
+    }
+  ],
+  "connections": {
+    ":in": [
+      "void:in"
+    ],
+    "void:out": [
+      ":out"
+    ]
+  }
+}

--- a/test_data/nested_op/usingCustomOp1.json
+++ b/test_data/nested_op/usingCustomOp1.json
@@ -8,7 +8,7 @@
     },
     "operators": [
         {
-            "operator": "customOp",
+            "operator": ".customOp",
             "name": "childOpr"
         }
     ],

--- a/test_data/nested_op/usingCustomOpN.json
+++ b/test_data/nested_op/usingCustomOpN.json
@@ -8,15 +8,15 @@
     },
     "operators": [
         {
-            "operator": "customOp",
+            "operator": ".customOp",
             "name": "left"
         },
         {
-            "operator": "customOp",
+            "operator": ".customOp",
             "name": "middle"
         },
         {
-            "operator": "customOp",
+            "operator": ".customOp",
             "name": "right"
         }
     ],

--- a/test_data/nested_op/usingSubCustomOpDouble.json
+++ b/test_data/nested_op/usingSubCustomOpDouble.json
@@ -8,7 +8,7 @@
     },
     "operators": [
         {
-            "operator": "sub.customOpDouble",
+            "operator": ".sub.customOpDouble",
             "name": "childOpr"
         }
     ],


### PR DESCRIPTION
Currently, operator search cannot start from the CWD again but is always relative. This PR tries to change that.