### PR TITLE
Fix buggy assert function assertPortItems

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"slang/op"
 	"testing"
@@ -30,7 +29,7 @@ func AssertPortItems(t *testing.T, i []interface{}, p *op.Port) {
 	for _, e := range i {
 		a := p.Pull()
 		if !reflect.DeepEqual(e, a) {
-			fmt.Errorf("wrong value:\nexpected: %#v,\nactual:   %#v", e, a)
+			t.Errorf("wrong value:\nexpected: %#v,\nactual:   %#v", e, a)
 			break
 		}
 	}


### PR DESCRIPTION
I have broken `assertPortItems` so tests using that function would never fail.
After fixing `assertPortItems` some tests may fail. 
I will take care of tests within *slang/builtin/*