### PR TITLE
Implement generic operators

### DIFF
--- a/builtin/eval.go
+++ b/builtin/eval.go
@@ -77,11 +77,12 @@ type functionStore struct {
 }
 
 var evalOpCfg = &builtinConfig{
-	oDef: &core.OperatorDef{
-		In: &core.PortDef{
-			Type: "primitive",
+	oDef: core.OperatorDef{
+		In: core.PortDef{
+			Type: "any",
+			Any:  "paramsMap",
 		},
-		Out: &core.PortDef{
+		Out: core.PortDef{
 			Type: "primitive",
 		},
 	},

--- a/builtin/eval.go
+++ b/builtin/eval.go
@@ -79,8 +79,8 @@ type functionStore struct {
 var evalOpCfg = &builtinConfig{
 	oDef: core.OperatorDef{
 		In: core.PortDef{
-			Type: "any",
-			Any:  "paramsMap",
+			Type:    "generic",
+			Generic: "paramsMap",
 		},
 		Out: core.PortDef{
 			Type: "primitive",

--- a/builtin/eval_test.go
+++ b/builtin/eval_test.go
@@ -248,27 +248,36 @@ func TestBuiltin_Eval__IsRegistered(t *testing.T) {
 
 func TestBuiltin_Eval__NilProperties(t *testing.T) {
 	a := assertions.New(t)
-	_, err := MakeOperator(&core.InstanceDef{Operator: "eval"})
+	_, err := MakeOperator(core.InstanceDef{Operator: "eval"})
 	a.Error(err)
 }
 
 func TestBuiltin_Eval__EmptyExpression(t *testing.T) {
 	a := assertions.New(t)
-	_, err := MakeOperator(&core.InstanceDef{Operator: "eval", Properties: map[string]interface{}{"expression": ""}})
+	_, err := MakeOperator(core.InstanceDef{Operator: "eval", Properties: map[string]interface{}{"expression": ""}})
 	a.Error(err)
 }
 
 func TestBuiltin_Eval__InvalidExpression(t *testing.T) {
 	a := assertions.New(t)
-	_, err := MakeOperator(&core.InstanceDef{Operator: "eval", Properties: map[string]interface{}{"expression": "+"}})
+	_, err := MakeOperator(core.InstanceDef{Operator: "eval", Properties: map[string]interface{}{"expression": "+"}})
 	a.Error(err)
 }
 
 func TestBuiltin_Eval__Add(t *testing.T) {
 	a := assertions.New(t)
-	fo, err := MakeOperator(&core.InstanceDef{
+	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "a+b"},
+		Ports: map[string]core.PortDef{
+			"paramsMap": {
+				Type: "map",
+				Map: map[string]core.PortDef{
+					"a": {Type: "number"},
+					"b": {Type: "number"},
+				},
+			},
+		},
 	})
 	a.NoError(err)
 	a.NotNil(fo)
@@ -285,9 +294,19 @@ func TestBuiltin_Eval__Add(t *testing.T) {
 
 func TestBuiltin_Eval__BoolArith(t *testing.T) {
 	a := assertions.New(t)
-	fo, err := MakeOperator(&core.InstanceDef{
+	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "a && (b != c)"},
+		Ports: map[string]core.PortDef{
+			"paramsMap": {
+				Type: "map",
+				Map: map[string]core.PortDef{
+					"a": {Type: "boolean"},
+					"b": {Type: "number"},
+					"c": {Type: "number"},
+				},
+			},
+		},
 	})
 	a.NoError(err)
 	a.NotNil(fo)
@@ -306,9 +325,18 @@ func TestBuiltin_Eval__BoolArith(t *testing.T) {
 
 func TestBuiltin_Eval_VectorArith(t *testing.T) {
 	a := assertions.New(t)
-	fo, err := MakeOperator(&core.InstanceDef{
+	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "vec0.x*vec1.x+vec0.y*vec1.y"},
+		Ports: map[string]core.PortDef{
+			"paramsMap": {
+				Type: "map",
+				Map: map[string]core.PortDef{
+					"vec0": {Type: "map", Map: map[string]core.PortDef{"x": {Type: "number"}, "y": {Type: "number"}}},
+					"vec1": {Type: "map", Map: map[string]core.PortDef{"x": {Type: "number"}, "y": {Type: "number"}}},
+				},
+			},
+		},
 	})
 	a.NoError(err)
 	a.NotNil(fo)

--- a/builtin/eval_test.go
+++ b/builtin/eval_test.go
@@ -269,10 +269,10 @@ func TestBuiltin_Eval__Add(t *testing.T) {
 	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "a+b"},
-		Generics: map[string]core.PortDef{
+		Generics: map[string]*core.PortDef{
 			"paramsMap": {
 				Type: "map",
-				Map: map[string]core.PortDef{
+				Map: map[string]*core.PortDef{
 					"a": {Type: "number"},
 					"b": {Type: "number"},
 				},
@@ -297,10 +297,10 @@ func TestBuiltin_Eval__BoolArith(t *testing.T) {
 	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "a && (b != c)"},
-		Generics: map[string]core.PortDef{
+		Generics: map[string]*core.PortDef{
 			"paramsMap": {
 				Type: "map",
-				Map: map[string]core.PortDef{
+				Map: map[string]*core.PortDef{
 					"a": {Type: "boolean"},
 					"b": {Type: "number"},
 					"c": {Type: "number"},
@@ -314,11 +314,11 @@ func TestBuiltin_Eval__BoolArith(t *testing.T) {
 
 	go fo.Start()
 
-	fo.In().Push(map[string]interface{}{"a": true, "b": true, "c": false})
-	fo.In().Push(map[string]interface{}{"a": false, "b": false, "c": false})
-	fo.In().Push(map[string]interface{}{"a": false, "b": false, "c": true})
-	fo.In().Push(map[string]interface{}{"a": true, "b": false, "c": true})
-	fo.In().Push(map[string]interface{}{"a": true, "b": false, "c": false})
+	fo.In().Push(map[string]interface{}{"a": true, "b": 1.0, "c": 2.0})
+	fo.In().Push(map[string]interface{}{"a": false, "b": 8.0, "c": 8.0})
+	fo.In().Push(map[string]interface{}{"a": false, "b": 3.0, "c": 2.0})
+	fo.In().Push(map[string]interface{}{"a": true, "b": 1.0, "c": 0.0})
+	fo.In().Push(map[string]interface{}{"a": true, "b": 8.0, "c": 8.0})
 
 	a.PortPushes([]interface{}{true, false, false, true, false}, fo.Out())
 }
@@ -328,12 +328,12 @@ func TestBuiltin_Eval_VectorArith(t *testing.T) {
 	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "vec0.x*vec1.x+vec0.y*vec1.y"},
-		Generics: map[string]core.PortDef{
+		Generics: map[string]*core.PortDef{
 			"paramsMap": {
 				Type: "map",
-				Map: map[string]core.PortDef{
-					"vec0": {Type: "map", Map: map[string]core.PortDef{"x": {Type: "number"}, "y": {Type: "number"}}},
-					"vec1": {Type: "map", Map: map[string]core.PortDef{"x": {Type: "number"}, "y": {Type: "number"}}},
+				Map: map[string]*core.PortDef{
+					"vec0": {Type: "map", Map: map[string]*core.PortDef{"x": {Type: "number"}, "y": {Type: "number"}}},
+					"vec1": {Type: "map", Map: map[string]*core.PortDef{"x": {Type: "number"}, "y": {Type: "number"}}},
 				},
 			},
 		},

--- a/builtin/eval_test.go
+++ b/builtin/eval_test.go
@@ -269,7 +269,7 @@ func TestBuiltin_Eval__Add(t *testing.T) {
 	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "a+b"},
-		Ports: map[string]core.PortDef{
+		Generics: map[string]core.PortDef{
 			"paramsMap": {
 				Type: "map",
 				Map: map[string]core.PortDef{
@@ -297,7 +297,7 @@ func TestBuiltin_Eval__BoolArith(t *testing.T) {
 	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "a && (b != c)"},
-		Ports: map[string]core.PortDef{
+		Generics: map[string]core.PortDef{
 			"paramsMap": {
 				Type: "map",
 				Map: map[string]core.PortDef{
@@ -328,7 +328,7 @@ func TestBuiltin_Eval_VectorArith(t *testing.T) {
 	fo, err := MakeOperator(core.InstanceDef{
 		Operator:   "eval",
 		Properties: map[string]interface{}{"expression": "vec0.x*vec1.x+vec0.y*vec1.y"},
-		Ports: map[string]core.PortDef{
+		Generics: map[string]core.PortDef{
 			"paramsMap": {
 				Type: "map",
 				Map: map[string]core.PortDef{

--- a/builtin/fork.go
+++ b/builtin/fork.go
@@ -12,8 +12,8 @@ var forkOpCfg = &builtinConfig{
 				Type: "map",
 				Map: map[string]core.PortDef{
 					"i": {
-						Type: "any",
-						Any:  "itemType",
+						Type:    "generic",
+						Generic: "itemType",
 					},
 					"select": {
 						Type: "boolean",
@@ -27,15 +27,15 @@ var forkOpCfg = &builtinConfig{
 				"true": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "any",
-						Any:  "itemType",
+						Type:    "generic",
+						Generic: "itemType",
 					},
 				},
 				"false": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "any",
-						Any:  "itemType",
+						Type:    "generic",
+						Generic: "itemType",
 					},
 				},
 			},

--- a/builtin/fork.go
+++ b/builtin/fork.go
@@ -10,7 +10,7 @@ var forkOpCfg = &builtinConfig{
 			Type: "stream",
 			Stream: &core.PortDef{
 				Type: "map",
-				Map: map[string]core.PortDef{
+				Map: map[string]*core.PortDef{
 					"i": {
 						Type:    "generic",
 						Generic: "itemType",
@@ -23,7 +23,7 @@ var forkOpCfg = &builtinConfig{
 		},
 		Out: core.PortDef{
 			Type: "map",
-			Map: map[string]core.PortDef{
+			Map: map[string]*core.PortDef{
 				"true": {
 					Type: "stream",
 					Stream: &core.PortDef{

--- a/builtin/fork.go
+++ b/builtin/fork.go
@@ -5,14 +5,15 @@ import (
 )
 
 var forkOpCfg = &builtinConfig{
-	oDef: &core.OperatorDef{
-		In: &core.PortDef{
+	oDef: core.OperatorDef{
+		In: core.PortDef{
 			Type: "stream",
 			Stream: &core.PortDef{
 				Type: "map",
 				Map: map[string]core.PortDef{
 					"i": {
-						Type: "primitive",
+						Type: "any",
+						Any:  "itemType",
 					},
 					"select": {
 						Type: "boolean",
@@ -20,19 +21,21 @@ var forkOpCfg = &builtinConfig{
 				},
 			},
 		},
-		Out: &core.PortDef{
+		Out: core.PortDef{
 			Type: "map",
 			Map: map[string]core.PortDef{
 				"true": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "primitive",
+						Type: "any",
+						Any:  "itemType",
 					},
 				},
 				"false": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "primitive",
+						Type: "any",
+						Any:  "itemType",
 					},
 				},
 			},

--- a/builtin/fork_test.go
+++ b/builtin/fork_test.go
@@ -20,7 +20,7 @@ func TestBuiltin_Fork__InPorts(t *testing.T) {
 	o, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "fork",
-			Ports: map[string]core.PortDef{
+			Generics: map[string]core.PortDef{
 				"itemType": {
 					Type: "primitive",
 				},
@@ -39,7 +39,7 @@ func TestBuiltin_Fork__OutPorts(t *testing.T) {
 	o, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "fork",
-			Ports: map[string]core.PortDef{
+			Generics: map[string]core.PortDef{
 				"itemType": {
 					Type: "primitive",
 				},
@@ -58,7 +58,7 @@ func TestBuiltin_Fork__Correct(t *testing.T) {
 	o, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "fork",
-			Ports: map[string]core.PortDef{
+			Generics: map[string]core.PortDef{
 				"itemType": {
 					Type: "primitive",
 				},
@@ -99,7 +99,7 @@ func TestBuiltin_Fork__ComplexItems(t *testing.T) {
 	o, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "fork",
-			Ports: map[string]core.PortDef{
+			Generics: map[string]core.PortDef{
 				"itemType": {
 					Type: "map",
 					Map: map[string]core.PortDef{

--- a/builtin/fork_test.go
+++ b/builtin/fork_test.go
@@ -20,7 +20,7 @@ func TestBuiltin_Fork__InPorts(t *testing.T) {
 	o, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "fork",
-			Generics: map[string]core.PortDef{
+			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
 				},
@@ -39,7 +39,7 @@ func TestBuiltin_Fork__OutPorts(t *testing.T) {
 	o, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "fork",
-			Generics: map[string]core.PortDef{
+			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
 				},
@@ -58,14 +58,14 @@ func TestBuiltin_Fork__Correct(t *testing.T) {
 	o, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "fork",
-			Generics: map[string]core.PortDef{
+			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
 				},
 			},
 		},
 	)
-	a.NoError(err)
+	require.NoError(t, err)
 
 	o.Out().Map("true").Stream().Bufferize()
 	o.Out().Map("false").Stream().Bufferize()
@@ -99,10 +99,10 @@ func TestBuiltin_Fork__ComplexItems(t *testing.T) {
 	o, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "fork",
-			Generics: map[string]core.PortDef{
+			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "map",
-					Map: map[string]core.PortDef{
+					Map: map[string]*core.PortDef{
 						"a": {Type: "number"},
 						"b": {Type: "string"},
 					},

--- a/builtin/fork_test.go
+++ b/builtin/fork_test.go
@@ -17,7 +17,16 @@ func TestBuiltin_Fork__CreatorFuncIsRegistered(t *testing.T) {
 func TestBuiltin_Fork__InPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(&core.InstanceDef{Operator: "fork"})
+	o, err := MakeOperator(
+		core.InstanceDef{
+			Operator: "fork",
+			Ports: map[string]core.PortDef{
+				"itemType": {
+					Type: "primitive",
+				},
+			},
+		},
+	)
 	require.NoError(t, err)
 
 	a.NotNil(o.In().Stream().Map("i"))
@@ -27,7 +36,16 @@ func TestBuiltin_Fork__InPorts(t *testing.T) {
 func TestBuiltin_Fork__OutPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(&core.InstanceDef{Operator: "fork"})
+	o, err := MakeOperator(
+		core.InstanceDef{
+			Operator: "fork",
+			Ports: map[string]core.PortDef{
+				"itemType": {
+					Type: "primitive",
+				},
+			},
+		},
+	)
 	require.NoError(t, err)
 
 	a.NotNil(o.Out().Map("true").Stream())
@@ -37,7 +55,16 @@ func TestBuiltin_Fork__OutPorts(t *testing.T) {
 func TestBuiltin_Fork__Correct(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(&core.InstanceDef{Operator: "fork"})
+	o, err := MakeOperator(
+		core.InstanceDef{
+			Operator: "fork",
+			Ports: map[string]core.PortDef{
+				"itemType": {
+					Type: "primitive",
+				},
+			},
+		},
+	)
 	a.NoError(err)
 
 	o.Out().Map("true").Stream().Bufferize()
@@ -69,7 +96,20 @@ func TestBuiltin_Fork__Correct(t *testing.T) {
 
 func TestBuiltin_Fork__ComplexItems(t *testing.T) {
 	a := assertions.New(t)
-	o, err := MakeOperator(&core.InstanceDef{Operator: "fork"})
+	o, err := MakeOperator(
+		core.InstanceDef{
+			Operator: "fork",
+			Ports: map[string]core.PortDef{
+				"itemType": {
+					Type: "map",
+					Map: map[string]core.PortDef{
+						"a": {Type: "number"},
+						"b": {Type: "string"},
+					},
+				},
+			},
+		},
+	)
 	a.NoError(err)
 
 	o.Out().Map("true").Stream().Bufferize()

--- a/builtin/loop.go
+++ b/builtin/loop.go
@@ -5,12 +5,13 @@ import (
 )
 
 var loopOpCfg = &builtinConfig{
-	oDef: &core.OperatorDef{
-		In: &core.PortDef{
+	oDef: core.OperatorDef{
+		In: core.PortDef{
 			Type: "map",
 			Map: map[string]core.PortDef{
 				"init": {
-					Type: "primitive",
+					Type: "any",
+					Any:  "stateType",
 				},
 				"iteration": {
 					Type: "stream",
@@ -21,23 +22,26 @@ var loopOpCfg = &builtinConfig{
 								Type: "boolean",
 							},
 							"state": {
-								Type: "primitive",
+								Type: "any",
+								Any:  "stateType",
 							},
 						},
 					},
 				},
 			},
 		},
-		Out: &core.PortDef{
+		Out: core.PortDef{
 			Type: "map",
 			Map: map[string]core.PortDef{
 				"end": {
-					Type: "primitive",
+					Type: "any",
+					Any:  "stateType",
 				},
 				"state": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "primitive",
+						Type: "any",
+						Any:  "stateType",
 					},
 				},
 			},

--- a/builtin/loop.go
+++ b/builtin/loop.go
@@ -8,7 +8,7 @@ var loopOpCfg = &builtinConfig{
 	oDef: core.OperatorDef{
 		In: core.PortDef{
 			Type: "map",
-			Map: map[string]core.PortDef{
+			Map: map[string]*core.PortDef{
 				"init": {
 					Type:    "generic",
 					Generic: "stateType",
@@ -17,7 +17,7 @@ var loopOpCfg = &builtinConfig{
 					Type: "stream",
 					Stream: &core.PortDef{
 						Type: "map",
-						Map: map[string]core.PortDef{
+						Map: map[string]*core.PortDef{
 							"continue": {
 								Type: "boolean",
 							},
@@ -32,7 +32,7 @@ var loopOpCfg = &builtinConfig{
 		},
 		Out: core.PortDef{
 			Type: "map",
-			Map: map[string]core.PortDef{
+			Map: map[string]*core.PortDef{
 				"end": {
 					Type:    "generic",
 					Generic: "stateType",

--- a/builtin/loop.go
+++ b/builtin/loop.go
@@ -10,8 +10,8 @@ var loopOpCfg = &builtinConfig{
 			Type: "map",
 			Map: map[string]core.PortDef{
 				"init": {
-					Type: "any",
-					Any:  "stateType",
+					Type:    "generic",
+					Generic: "stateType",
 				},
 				"iteration": {
 					Type: "stream",
@@ -22,8 +22,8 @@ var loopOpCfg = &builtinConfig{
 								Type: "boolean",
 							},
 							"state": {
-								Type: "any",
-								Any:  "stateType",
+								Type:    "generic",
+								Generic: "stateType",
 							},
 						},
 					},
@@ -34,14 +34,14 @@ var loopOpCfg = &builtinConfig{
 			Type: "map",
 			Map: map[string]core.PortDef{
 				"end": {
-					Type: "any",
-					Any:  "stateType",
+					Type:    "generic",
+					Generic: "stateType",
 				},
 				"state": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "any",
-						Any:  "stateType",
+						Type:    "generic",
+						Generic: "stateType",
 					},
 				},
 			},

--- a/builtin/loop_test.go
+++ b/builtin/loop_test.go
@@ -19,7 +19,7 @@ func TestBuiltin_Loop__SimpleLoop(t *testing.T) {
 	lo, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "loop",
-			Generics: map[string]core.PortDef{
+			Generics: map[string]*core.PortDef{
 				"stateType": {
 					Type: "number",
 				},
@@ -77,7 +77,7 @@ func TestBuiltin_Loop__FibLoop(t *testing.T) {
 	a := assertions.New(t)
 	stateType := core.PortDef{
 		Type: "map",
-		Map: map[string]core.PortDef{
+		Map: map[string]*core.PortDef{
 			"i":      {Type: "number"},
 			"fib":    {Type: "number"},
 			"oldFib": {Type: "number"},
@@ -86,12 +86,12 @@ func TestBuiltin_Loop__FibLoop(t *testing.T) {
 	lo, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "loop",
-			Generics: map[string]core.PortDef{
-				"stateType": stateType,
+			Generics: map[string]*core.PortDef{
+				"stateType": &stateType,
 			},
 		},
 	)
-	a.NoError(err)
+	require.NoError(t, err)
 	a.NotNil(lo)
 	require.Equal(t, core.TYPE_MAP, lo.In().Map("init").Type())
 	require.Equal(t, core.TYPE_NUMBER, lo.In().Map("init").Map("i").Type())

--- a/builtin/loop_test.go
+++ b/builtin/loop_test.go
@@ -19,7 +19,7 @@ func TestBuiltin_Loop__SimpleLoop(t *testing.T) {
 	lo, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "loop",
-			Ports: map[string]core.PortDef{
+			Generics: map[string]core.PortDef{
 				"stateType": {
 					Type: "number",
 				},
@@ -86,7 +86,7 @@ func TestBuiltin_Loop__FibLoop(t *testing.T) {
 	lo, err := MakeOperator(
 		core.InstanceDef{
 			Operator: "loop",
-			Ports: map[string]core.PortDef{
+			Generics: map[string]core.PortDef{
 				"stateType": stateType,
 			},
 		},

--- a/builtin/manager.go
+++ b/builtin/manager.go
@@ -63,6 +63,7 @@ func GetOperatorDef(insDef *core.InstanceDef) (core.OperatorDef, error) {
 		return oDef, errors.New("builtin operator not found")
 	}
 
+	// We must not change oDef in any way as this would affect other instances of this builtin operator
 	if err := oDef.SpecifyGenericPorts(insDef.Generics); err != nil {
 		return oDef, err
 	}

--- a/builtin/manager.go
+++ b/builtin/manager.go
@@ -26,12 +26,12 @@ func MakeOperator(def core.InstanceDef) (*core.Operator, error) {
 	var defIn, defOut core.PortDef
 
 	for identifier, pd := range def.Ports {
-		if pDef, err := cfg.oDef.In.SpecifyAnyPort(identifier, pd); err != nil {
+		if pDef, err := cfg.oDef.In.SpecifyGenericPort(identifier, pd); err != nil {
 			return nil, err
 		} else {
 			defIn = pDef
 		}
-		if pDef, err  := cfg.oDef.Out.SpecifyAnyPort(identifier, pd); err != nil {
+		if pDef, err  := cfg.oDef.Out.SpecifyGenericPort(identifier, pd); err != nil {
 			return nil, err
 		} else {
 			defOut = pDef

--- a/builtin/manager.go
+++ b/builtin/manager.go
@@ -33,10 +33,10 @@ func MakeOperator(def core.InstanceDef) (*core.Operator, error) {
 		return nil, err
 	}
 
-	if err := in.FreeOfGenerics(); err != nil {
+	if err := in.GenericsSpecified(); err != nil {
 		return nil, err
 	}
-	if err := out.FreeOfGenerics(); err != nil {
+	if err := out.GenericsSpecified(); err != nil {
 		return nil, err
 	}
 

--- a/builtin/manager.go
+++ b/builtin/manager.go
@@ -25,7 +25,7 @@ func MakeOperator(def core.InstanceDef) (*core.Operator, error) {
 
 	var defIn, defOut core.PortDef
 
-	for identifier, pd := range def.Ports {
+	for identifier, pd := range def.Generics {
 		if pDef, err := cfg.oDef.In.SpecifyGenericPort(identifier, pd); err != nil {
 			return nil, err
 		} else {

--- a/builtin/merge.go
+++ b/builtin/merge.go
@@ -12,15 +12,15 @@ var mergeOpCfg = &builtinConfig{
 				"true": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "any",
-						Any:  "itemType",
+						Type:    "generic",
+						Generic: "itemType",
 					},
 				},
 				"false": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "any",
-						Any:  "itemType",
+						Type:    "generic",
+						Generic: "itemType",
 					},
 				},
 				"select": {
@@ -34,8 +34,8 @@ var mergeOpCfg = &builtinConfig{
 		Out: core.PortDef{
 			Type: "stream",
 			Stream: &core.PortDef{
-				Type: "any",
-				Any:  "itemType",
+				Type:    "generic",
+				Generic: "itemType",
 			},
 		},
 	},

--- a/builtin/merge.go
+++ b/builtin/merge.go
@@ -8,7 +8,7 @@ var mergeOpCfg = &builtinConfig{
 	oDef: core.OperatorDef{
 		In: core.PortDef{
 			Type: "map",
-			Map: map[string]core.PortDef{
+			Map: map[string]*core.PortDef{
 				"true": {
 					Type: "stream",
 					Stream: &core.PortDef{

--- a/builtin/merge.go
+++ b/builtin/merge.go
@@ -5,20 +5,22 @@ import (
 )
 
 var mergeOpCfg = &builtinConfig{
-	oDef: &core.OperatorDef{
-		In: &core.PortDef{
+	oDef: core.OperatorDef{
+		In: core.PortDef{
 			Type: "map",
 			Map: map[string]core.PortDef{
 				"true": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "primitive",
+						Type: "any",
+						Any:  "itemType",
 					},
 				},
 				"false": {
 					Type: "stream",
 					Stream: &core.PortDef{
-						Type: "primitive",
+						Type: "any",
+						Any:  "itemType",
 					},
 				},
 				"select": {
@@ -29,10 +31,11 @@ var mergeOpCfg = &builtinConfig{
 				},
 			},
 		},
-		Out: &core.PortDef{
+		Out: core.PortDef{
 			Type: "stream",
 			Stream: &core.PortDef{
-				Type: "primitive",
+				Type: "any",
+				Any:  "itemType",
 			},
 		},
 	},

--- a/builtin/merge_test.go
+++ b/builtin/merge_test.go
@@ -17,7 +17,7 @@ func TestBuiltin_Merge__CreatorFuncIsRegistered(t *testing.T) {
 func TestBuiltin_Merge__InPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Ports: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.In().Map("true").Stream())
@@ -28,7 +28,7 @@ func TestBuiltin_Merge__InPorts(t *testing.T) {
 func TestBuiltin_Merge__OutPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Ports: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.Out().Stream())
@@ -37,7 +37,7 @@ func TestBuiltin_Merge__OutPorts(t *testing.T) {
 func TestBuiltin_Merge__Works(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Ports: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	o.Out().Stream().Bufferize()
@@ -58,7 +58,7 @@ func TestBuiltin_Merge__ComplexItems(t *testing.T) {
 	a := assertions.New(t)
 	o, err := MakeOperator(core.InstanceDef{
 		Operator: "merge",
-		Ports:    map[string]core.PortDef{"itemType": {Type: "map", Map: map[string]core.PortDef{"red": {Type: "string"}, "blue": {Type: "string"}}}},
+		Generics: map[string]core.PortDef{"itemType": {Type: "map", Map: map[string]core.PortDef{"red": {Type: "string"}, "blue": {Type: "string"}}}},
 	})
 	require.NoError(t, err)
 

--- a/builtin/merge_test.go
+++ b/builtin/merge_test.go
@@ -17,7 +17,7 @@ func TestBuiltin_Merge__CreatorFuncIsRegistered(t *testing.T) {
 func TestBuiltin_Merge__InPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.In().Map("true").Stream())
@@ -28,7 +28,7 @@ func TestBuiltin_Merge__InPorts(t *testing.T) {
 func TestBuiltin_Merge__OutPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.Out().Stream())
@@ -37,7 +37,7 @@ func TestBuiltin_Merge__OutPorts(t *testing.T) {
 func TestBuiltin_Merge__Works(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	o.Out().Stream().Bufferize()
@@ -58,7 +58,7 @@ func TestBuiltin_Merge__ComplexItems(t *testing.T) {
 	a := assertions.New(t)
 	o, err := MakeOperator(core.InstanceDef{
 		Operator: "merge",
-		Generics: map[string]core.PortDef{"itemType": {Type: "map", Map: map[string]core.PortDef{"red": {Type: "string"}, "blue": {Type: "string"}}}},
+		Generics: map[string]*core.PortDef{"itemType": {Type: "map", Map: map[string]*core.PortDef{"red": {Type: "string"}, "blue": {Type: "string"}}}},
 	})
 	require.NoError(t, err)
 

--- a/builtin/merge_test.go
+++ b/builtin/merge_test.go
@@ -17,7 +17,7 @@ func TestBuiltin_Merge__CreatorFuncIsRegistered(t *testing.T) {
 func TestBuiltin_Merge__InPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(&core.InstanceDef{Operator: "merge"})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Ports: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.In().Map("true").Stream())
@@ -28,7 +28,7 @@ func TestBuiltin_Merge__InPorts(t *testing.T) {
 func TestBuiltin_Merge__OutPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(&core.InstanceDef{Operator: "merge"})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Ports: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.Out().Stream())
@@ -37,7 +37,7 @@ func TestBuiltin_Merge__OutPorts(t *testing.T) {
 func TestBuiltin_Merge__Works(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(&core.InstanceDef{Operator: "merge"})
+	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Ports: map[string]core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	o.Out().Stream().Bufferize()
@@ -56,8 +56,9 @@ func TestBuiltin_Merge__Works(t *testing.T) {
 
 func TestBuiltin_Merge__ComplexItems(t *testing.T) {
 	a := assertions.New(t)
-	o, err := MakeOperator(&core.InstanceDef{
+	o, err := MakeOperator(core.InstanceDef{
 		Operator: "merge",
+		Ports:    map[string]core.PortDef{"itemType": {Type: "map", Map: map[string]core.PortDef{"red": {Type: "string"}, "blue": {Type: "string"}}}},
 	})
 	require.NoError(t, err)
 

--- a/core/def.go
+++ b/core/def.go
@@ -27,6 +27,7 @@ type OperatorDef struct {
 }
 
 type PortDef struct {
+	// Type is one of "primitive", "number", "string", "boolean", "stream", "map", "generic"
 	Type    string              `json:"type"`
 	Stream  *PortDef            `json:"stream"`
 	Map     map[string]*PortDef `json:"map"`
@@ -126,16 +127,16 @@ func (d *OperatorDef) SpecifyGenericPorts(generics map[string]*PortDef) error {
 	return nil
 }
 
-func (d OperatorDef) FreeOfGenerics() error {
-	if err := d.In.FreeOfGenerics(); err != nil {
+func (d OperatorDef) GenericsSpecified() error {
+	if err := d.In.GenericsSpecified(); err != nil {
 		return err
 	}
-	if err := d.Out.FreeOfGenerics(); err != nil {
+	if err := d.Out.GenericsSpecified(); err != nil {
 		return err
 	}
 	for _, op := range d.Operators {
 		for _, gp := range op.Generics {
-			if err := gp.FreeOfGenerics(); err != nil {
+			if err := gp.GenericsSpecified(); err != nil {
 				return err
 			}
 		}
@@ -270,16 +271,16 @@ func (d *PortDef) SpecifyGenericPorts(generics map[string]*PortDef) error {
 	return nil
 }
 
-func (d PortDef) FreeOfGenerics() error {
+func (d PortDef) GenericsSpecified() error {
 	if d.Type == "generic" || d.Generic != "" {
 		return errors.New("generic not replaced: " + d.Generic)
 	}
 
 	if d.Type == "stream" {
-		return d.Stream.FreeOfGenerics()
+		return d.Stream.GenericsSpecified()
 	} else if d.Type == "map" {
 		for _, e := range d.Map {
-			if err := e.FreeOfGenerics(); err != nil {
+			if err := e.GenericsSpecified(); err != nil {
 				return err
 			}
 		}

--- a/core/def.go
+++ b/core/def.go
@@ -108,8 +108,9 @@ func (d *OperatorDef) Validate() error {
 	return nil
 }
 
-// SpecifyGenericPorts specifies generic types in the operator definition. It does not touch referenced values
-// such as *PortDef but replaces them with a reference on a copy.
+// SpecifyGenericPorts replaces generic types in the operator definition with the types given in the generics map.
+// The values of the map are the according identifiers. It does not touch referenced values such as *PortDef but
+// replaces them with a reference on a copy.
 func (d *OperatorDef) SpecifyGenericPorts(generics map[string]*PortDef) error {
 	if err := d.In.SpecifyGenericPorts(generics); err != nil {
 		return err
@@ -241,9 +242,9 @@ func (d PortDef) Copy() PortDef {
 	return cpy
 }
 
-// SpecifyGenericPorts specifies generic types in the port definition. It does not touch referenced values
-// such as *PortDef but replaces them with a reference on a copy, which is very important to prevent unintended side
-// effects.
+// SpecifyGenericPorts replaces generic types in the port definition with the types given in the generics map.
+// The values of the map are the according identifiers. It does not touch referenced values such as *PortDef but
+// replaces them with a reference on a copy, which is very important to prevent unintended side effects.
 func (d *PortDef) SpecifyGenericPorts(generics map[string]*PortDef) error {
 	for identifier, pd := range generics {
 		if d.Generic == identifier {

--- a/core/def.go
+++ b/core/def.go
@@ -246,7 +246,8 @@ func (d PortDef) Copy() PortDef {
 func (d *PortDef) SpecifyGenericPorts(generics map[string]*PortDef) error {
 	for identifier, pd := range generics {
 		if d.Generic == identifier {
-			*d = *pd
+			// Replace with copy!
+			*d = pd.Copy()
 			return nil
 		}
 

--- a/core/def.go
+++ b/core/def.go
@@ -10,7 +10,7 @@ type InstanceDef struct {
 	Operator   string                 `json:"operator"`
 	Name       string                 `json:"name"`
 	Properties map[string]interface{} `json:"properties"`
-	Ports      map[string]PortDef     `json:"ports"`
+	Generics   map[string]PortDef     `json:"generics"`
 
 	valid       bool
 	operatorDef OperatorDef

--- a/core/def.go
+++ b/core/def.go
@@ -148,7 +148,7 @@ func (d *PortDef) Validate() error {
 	return nil
 }
 
-func (d *PortDef) SpecifyAnyPort(identifier string, def PortDef) (PortDef, error) {
+func (d PortDef) SpecifyAnyPort(identifier string, def PortDef) (PortDef, error) {
 	if d.Any == identifier {
 		return def, nil
 	}
@@ -175,6 +175,24 @@ func (d *PortDef) SpecifyAnyPort(identifier string, def PortDef) (PortDef, error
 	}
 
 	return portDef, nil
+}
+
+func (d PortDef) FreeOfAnys() error {
+	if d.Type == "any" || d.Any != "" {
+		return errors.New("generic any not replaced: " + d.Any)
+	}
+
+	if d.Type == "stream" {
+		return d.Stream.FreeOfAnys()
+	} else if d.Type == "map" {
+		for _, e := range d.Map {
+			if err := e.FreeOfAnys(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (d PortDef) Equals(p PortDef) bool {

--- a/core/def.go
+++ b/core/def.go
@@ -12,9 +12,8 @@ type InstanceDef struct {
 	Properties map[string]interface{} `json:"properties"`
 	Generics   map[string]*PortDef    `json:"generics"`
 
-	valid          bool
-	operatorDef    OperatorDef
-	operatorDefSet bool
+	valid       bool
+	operatorDef OperatorDef
 }
 
 type OperatorDef struct {
@@ -67,13 +66,8 @@ func (d InstanceDef) OperatorDef() OperatorDef {
 	return d.operatorDef
 }
 
-func (d InstanceDef) HasOperatorDef() bool {
-	return d.operatorDefSet
-}
-
 func (d *InstanceDef) SetOperatorDef(operatorDef OperatorDef) error {
 	d.operatorDef = operatorDef
-	d.operatorDefSet = true
 	return nil
 }
 

--- a/core/port.go
+++ b/core/port.go
@@ -363,7 +363,7 @@ func (p *Port) Name() string {
 
 	switch p.itemType {
 	case TYPE_GENERIC:
-		name = "generic"
+		name = "GENERIC"
 	case TYPE_PRIMITIVE:
 		name = "PRIMITIVE"
 	case TYPE_NUMBER:

--- a/core/port.go
+++ b/core/port.go
@@ -130,7 +130,7 @@ func (p *Port) Stream() *Port {
 // Connects this port with port p.
 func (p *Port) Connect(q *Port) error {
 	if p.itemType != TYPE_PRIMITIVE && q.itemType != TYPE_PRIMITIVE && p.itemType != q.itemType {
-		return fmt.Errorf("types don't match: %d != %d", p.itemType, q.itemType)
+		return fmt.Errorf("%s -> %s: types don't match - %d != %d", p.Name(), q.Name(), p.itemType, q.itemType)
 	}
 
 	if p.primitive() {
@@ -139,13 +139,13 @@ func (p *Port) Connect(q *Port) error {
 
 	if p.itemType == TYPE_MAP {
 		if len(p.subs) != len(q.subs) {
-			return fmt.Errorf("%s -> %s: maps are incompatible: unequal lengths %d and %d", p.Name(), q.Name(), len(p.subs), len(q.subs))
+			return fmt.Errorf("%s -> %s: maps are incompatible - unequal lengths %d and %d", p.Name(), q.Name(), len(p.subs), len(q.subs))
 		}
 
 		for k, pe := range p.subs {
 			qe, ok := q.subs[k]
 			if !ok {
-				return fmt.Errorf("%s -> %s: maps are incompatible: %s not present", p.Name(), q.Name(), k)
+				return fmt.Errorf("%s -> %s: maps are incompatible - %s not present", p.Name(), q.Name(), k)
 			}
 
 			err := pe.Connect(qe)
@@ -160,13 +160,17 @@ func (p *Port) Connect(q *Port) error {
 
 	if p.itemType == TYPE_STREAM {
 		if q.sub == nil {
-			return errors.New("streams are incompatible: no sub present")
+			return fmt.Errorf("%s -> %s: streams are incompatible - no sub present", p.Name(), q.Name())
 		}
 
 		return p.sub.Connect(q.sub)
 	}
 
-	return errors.New("can only connect primitives and maps")
+	if p.itemType == TYPE_ANY {
+		return fmt.Errorf("%s -> %s: cannot connect any type", p.Name(), q.Name())
+	}
+
+	return fmt.Errorf("%s -> %s: unknown type", p.Name(), q.Name())
 }
 
 // Disconnects this port from port q.

--- a/core/port.go
+++ b/core/port.go
@@ -70,7 +70,7 @@ func NewPort(o *Operator, def PortDef, dir int) (*Port, error) {
 		p.itemType = TYPE_MAP
 		p.subs = make(map[string]*Port)
 		for k, e := range def.Map {
-			p.subs[k], err = NewPort(o, e, dir)
+			p.subs[k], err = NewPort(o, *e, dir)
 			if err != nil {
 				return nil, err
 			}

--- a/core/port.go
+++ b/core/port.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	TYPE_ANY       = iota
+	TYPE_GENERIC   = iota
 	TYPE_PRIMITIVE = iota
 	TYPE_NUMBER    = iota
 	TYPE_STRING    = iota
@@ -166,8 +166,8 @@ func (p *Port) Connect(q *Port) error {
 		return p.sub.Connect(q.sub)
 	}
 
-	if p.itemType == TYPE_ANY {
-		return fmt.Errorf("%s -> %s: cannot connect any type", p.Name(), q.Name())
+	if p.itemType == TYPE_GENERIC {
+		return fmt.Errorf("%s -> %s: cannot connect generic type", p.Name(), q.Name())
 	}
 
 	return fmt.Errorf("%s -> %s: unknown type", p.Name(), q.Name())
@@ -266,8 +266,8 @@ func (p *Port) PushEOS() {
 
 // Pull an item from this port.
 func (p *Port) Pull() interface{} {
-	if p.itemType == TYPE_ANY {
-		panic("cannot pull from any")
+	if p.itemType == TYPE_GENERIC {
+		panic("cannot pull from generic")
 	}
 
 	if p.buf != nil {
@@ -362,8 +362,8 @@ func (p *Port) Name() string {
 	var name string
 
 	switch p.itemType {
-	case TYPE_ANY:
-		name = "ANY"
+	case TYPE_GENERIC:
+		name = "generic"
 	case TYPE_PRIMITIVE:
 		name = "PRIMITIVE"
 	case TYPE_NUMBER:

--- a/slang.go
+++ b/slang.go
@@ -291,7 +291,7 @@ func getOperator(insDef core.InstanceDef, par *core.Operator) (*core.Operator, e
 		return nil, err
 	}
 	// Instance definition must have an appropriate operator definition
-	if !insDef.HasOperatorDef() {
+	if !insDef.OperatorDef().Valid() {
 		return nil, errors.New("instance has no operator definition")
 	}
 	// No builtin operator, so create new one according to the operator definition saved in the instance definition

--- a/slang.go
+++ b/slang.go
@@ -149,7 +149,7 @@ func readOperatorDef(opDefFilePath string, pathsRead []string) (core.OperatorDef
 		}
 
 		// Replace generic ports in generic operators with according instance port type specifications
-		for identifier, pd := range childOpInsDef.Ports {
+		for identifier, pd := range childOpInsDef.Generics {
 			if childDef, err = childDef.SpecifyGenericPort(identifier, pd); err != nil {
 				return def, err
 			}

--- a/slang.go
+++ b/slang.go
@@ -144,28 +144,18 @@ func readOperatorDef(opDefFilePath string, pathsRead []string) (core.OperatorDef
 	for _, childOpInsDef := range def.Operators {
 		childDef, err := getOperatorDef(*childOpInsDef, currDir, pathsRead)
 
-		// Replace any ports in generic operators with according instance port type specifications
-		for identifier, pd := range childOpInsDef.Ports {
-			if pDef, err := childDef.In.SpecifyAnyPort(identifier, pd); err != nil {
-				return def, err
-			} else {
-				childDef.In = pDef
-			}
-			if pDef, err  := childDef.Out.SpecifyAnyPort(identifier, pd); err != nil {
-				return def, err
-			} else {
-				childDef.Out = pDef
-			}
-		}
-
-		if err := childDef.In.FreeOfAnys(); err != nil {
-			return def, err
-		}
-		if err := childDef.Out.FreeOfAnys(); err != nil {
-			return def, err
-		}
-
 		if err != nil {
+			return def, err
+		}
+
+		// Replace generic ports in generic operators with according instance port type specifications
+		for identifier, pd := range childOpInsDef.Ports {
+			if childDef, err = childDef.SpecifyGenericPort(identifier, pd); err != nil {
+				return def, err
+			}
+		}
+
+		if err := childDef.FreeOfGenerics(); err != nil {
 			return def, err
 		}
 

--- a/slang.go
+++ b/slang.go
@@ -116,7 +116,7 @@ func readOperatorDef(opDefFilePath string, generics map[string]*core.PortDef, pa
 
 	// Make sure generics is free of further generics
 	for _, g := range generics {
-		if err := g.FreeOfGenerics(); err != nil {
+		if err := g.GenericsSpecified(); err != nil {
 			return def, err
 		}
 	}
@@ -157,7 +157,7 @@ func readOperatorDef(opDefFilePath string, generics map[string]*core.PortDef, pa
 	}
 
 	// Make sure we replaced all generics in the definition
-	if err := def.FreeOfGenerics(); err != nil {
+	if err := def.GenericsSpecified(); err != nil {
 		return def, err
 	}
 
@@ -171,7 +171,7 @@ func readOperatorDef(opDefFilePath string, generics map[string]*core.PortDef, pa
 			return def, err
 		}
 
-		if err := childDef.FreeOfGenerics(); err != nil {
+		if err := childDef.GenericsSpecified(); err != nil {
 			return def, err
 		}
 

--- a/slang.go
+++ b/slang.go
@@ -158,6 +158,13 @@ func readOperatorDef(opDefFilePath string, pathsRead []string) (core.OperatorDef
 			}
 		}
 
+		if err := childDef.In.FreeOfAnys(); err != nil {
+			return def, err
+		}
+		if err := childDef.Out.FreeOfAnys(); err != nil {
+			return def, err
+		}
+
 		if err != nil {
 			return def, err
 		}

--- a/tests/core_def_test.go
+++ b/tests/core_def_test.go
@@ -5,19 +5,22 @@ import (
 	"slang"
 	"slang/tests/assertions"
 	"slang/core"
+	"github.com/stretchr/testify/require"
 )
+
+// OPERATOR DEFINITION
 
 func TestOperatorDef_SpecifyGenericPorts__NilGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(`{"in": {"type": "number"}, "out": {"type": "number"}}`)
-	a.NoError(op.Validate())
+	require.NoError(t, op.Validate())
 	a.NoError(op.SpecifyGenericPorts(nil))
 }
 
 func TestOperatorDef_SpecifyGenericPorts__InPortGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(`{"in": {"type": "generic", "generic": "g1"}, "out": {"type": "number"}}`)
-	a.NoError(op.Validate())
+	require.NoError(t, op.Validate())
 	a.NoError(op.SpecifyGenericPorts(map[string]*core.PortDef{
 		"g1": {
 			Type: "boolean",
@@ -29,7 +32,7 @@ func TestOperatorDef_SpecifyGenericPorts__InPortGenerics(t *testing.T) {
 func TestOperatorDef_SpecifyGenericPorts__OutPortGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(`{"in": {"type": "number"}, "out": {"type": "generic", "generic": "g1"}}`)
-	a.NoError(op.Validate())
+	require.NoError(t, op.Validate())
 	a.NoError(op.SpecifyGenericPorts(map[string]*core.PortDef{
 		"g1": {
 			Type: "boolean",
@@ -38,8 +41,191 @@ func TestOperatorDef_SpecifyGenericPorts__OutPortGenerics(t *testing.T) {
 	a.Equal("boolean", op.Out.Type)
 }
 
-// TODO: Write more tests for OperatorDef.SpecifyGenericPorts(...)
-// TODO: Write tests for PortDef.SpecifyGenericPorts(...)
-// TODO: Write tests for OperatorDef.FreeOfGenerics()
-// TODO: Write tests for PortDef.FreeOfGenerics()
-// TODO: Write tests for PortDef.Copy()
+func TestOperatorDef_SpecifyGenericPorts__GenericPortsGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(
+		`{"in": {"type": "number"}, "out": {"type": "number"}, "operators": [{"name": "test", "operator": "fork", "generics": {"itemType": {"type": "generic", "generic": "g1"}}}]}`)
+	require.NoError(t, op.Validate())
+	a.NoError(op.SpecifyGenericPorts(map[string]*core.PortDef{
+		"g1": {
+			Type: "boolean",
+		},
+	}))
+	a.Equal("boolean", op.Operators[0].Generics["itemType"].Type)
+}
+
+func TestOperatorDef_SpecifyGenericPorts__DifferentIdentifier(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(`{"in": {"type": "generic", "generic": "g1"}, "out": {"type": "number"}}`)
+	require.NoError(t, op.Validate())
+	a.NoError(op.SpecifyGenericPorts(map[string]*core.PortDef{
+		"g2": {
+			Type: "boolean",
+		},
+	}))
+	a.Equal("generic", op.In.Type)
+}
+
+func TestOperatorDef_FreeOfGenerics__InPortGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(`{"in": {"type": "generic", "generic": "t1"}, "out": {"type": "number"}}`)
+	require.NoError(t, op.Validate())
+	a.Error(op.FreeOfGenerics())
+}
+
+func TestOperatorDef_FreeOfGenerics__InPortNoGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(`{"in": {"type": "string"}, "out": {"type": "number"}}`)
+	require.NoError(t, op.Validate())
+	a.NoError(op.FreeOfGenerics())
+}
+
+func TestOperatorDef_FreeOfGenerics__OutPortGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(`{"in": {"type": "number"}, "out": {"type": "generic", "generic": "t1"}}`)
+	require.NoError(t, op.Validate())
+	a.Error(op.FreeOfGenerics())
+}
+
+func TestOperatorDef_FreeOfGenerics__OutPortNoGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(`{"in": {"type": "number"}, "out": {"type": "string"}}`)
+	require.NoError(t, op.Validate())
+	a.NoError(op.FreeOfGenerics())
+}
+
+func TestOperatorDef_FreeOfGenerics__GenericPortsGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(
+		`{"in": {"type": "number"}, "out": {"type": "number"}, "operators": [{"name": "test", "operator": "fork", "generics": {"itemType": {"type": "generic", "generic": "g1"}}}]}`)
+	require.NoError(t, op.Validate())
+	a.Error(op.FreeOfGenerics())
+}
+
+func TestOperatorDef_FreeOfGenerics__GenericPortsNoGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(
+		`{"in": {"type": "number"}, "out": {"type": "number"}, "operators": [{"name": "test", "operator": "fork", "generics": {"itemType": {"type": "number"}}}]}`)
+	require.NoError(t, op.Validate())
+	a.NoError(op.FreeOfGenerics())
+}
+
+// PORT DEFINITION
+
+func TestPortDef_Copy__Simple(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "number"}
+	require.NoError(t, pd.Validate())
+	pdCpy := pd.Copy()
+	require.NoError(t, pdCpy.Validate())
+	a.Equal("number", pdCpy.Type)
+}
+
+func TestPortDef_Copy__Stream(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "stream", Stream: &core.PortDef{Type: "string"}}
+	require.NoError(t, pd.Validate())
+	pdCpy := pd.Copy()
+	require.NoError(t, pdCpy.Validate())
+	a.Equal("string", pdCpy.Stream.Type)
+	a.False(pd.Stream == pdCpy.Stream)
+}
+
+func TestPortDef_Copy__Map(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "map", Map: map[string]*core.PortDef{"a": {Type: "string"}}}
+	require.NoError(t, pd.Validate())
+	pdCpy := pd.Copy()
+	require.NoError(t, pdCpy.Validate())
+	a.Equal("string", pdCpy.Map["a"].Type)
+	a.False(pd.Map["a"] == pdCpy.Map["a"])
+}
+
+func TestPortDef_SpecifyGenericPorts__Simple(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "generic", Generic: "t1"}
+	require.NoError(t, pd.Validate())
+	a.NoError(pd.SpecifyGenericPorts(map[string]*core.PortDef{
+		"t1": {Type: "number"},
+	}))
+	a.Equal("number", pd.Type)
+}
+
+func TestPortDef_SpecifyGenericPorts__DifferentIdentifier(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "generic", Generic: "t1"}
+	require.NoError(t, pd.Validate())
+	a.NoError(pd.SpecifyGenericPorts(map[string]*core.PortDef{
+		"t2": {Type: "number"},
+	}))
+	a.Equal("generic", pd.Type)
+}
+
+func TestPortDef_SpecifyGenericPorts__MultipleIdentifiers(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{
+		Type: "map",
+		Map:  map[string]*core.PortDef{"a": {Type: "generic", Generic: "t1"}, "b": {Type: "generic", Generic: "t2"}},
+	}
+	require.NoError(t, pd.Validate())
+	a.NoError(pd.SpecifyGenericPorts(map[string]*core.PortDef{
+		"t1": {Type: "number"},
+	}))
+	a.Equal("number", pd.Map["a"].Type)
+	a.Equal("generic", pd.Map["b"].Type)
+}
+
+func TestPortDef_SpecifyGenericPorts__Stream(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "stream", Stream: &core.PortDef{Type: "generic", Generic: "t1"}}
+	require.NoError(t, pd.Validate())
+	a.NoError(pd.SpecifyGenericPorts(map[string]*core.PortDef{
+		"t1": {Type: "number"},
+	}))
+	a.Equal("number", pd.Stream.Type)
+}
+
+func TestPortDef_SpecifyGenericPorts__Map(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "map", Map: map[string]*core.PortDef{"a": {Type: "generic", Generic: "t1"}}}
+	require.NoError(t, pd.Validate())
+	a.NoError(pd.SpecifyGenericPorts(map[string]*core.PortDef{
+		"t1": {Type: "number"},
+	}))
+	a.Equal("number", pd.Map["a"].Type)
+}
+
+func TestPortDef_FreeOfGenerics__SimpleGeneric(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "generic", Generic: "t1"}
+	require.NoError(t, pd.Validate())
+	a.Error(pd.FreeOfGenerics())
+}
+
+func TestPortDef_FreeOfGenerics__SimpleNoGeneric(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "number"}
+	require.NoError(t, pd.Validate())
+	a.NoError(pd.FreeOfGenerics())
+}
+
+func TestPortDef_FreeOfGenerics__StreamGenerics(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "stream", Stream: &core.PortDef{Type: "generic", Generic: "t1"}}
+	require.NoError(t, pd.Validate())
+	a.Error(pd.FreeOfGenerics())
+}
+
+func TestPortDef_FreeOfGenerics__StreamNoGenerics(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "stream", Stream: &core.PortDef{Type: "number"}}
+	require.NoError(t, pd.Validate())
+	a.NoError(pd.FreeOfGenerics())
+}
+
+func TestPortDef_FreeOfGenerics__MapGenerics(t *testing.T) {
+	a := assertions.New(t)
+	pd := core.PortDef{Type: "map", Map: map[string]*core.PortDef{"a": {Type: "number"}}}
+	require.NoError(t, pd.Validate())
+	a.NoError(pd.FreeOfGenerics())
+}

--- a/tests/core_def_test.go
+++ b/tests/core_def_test.go
@@ -37,3 +37,9 @@ func TestOperatorDef_SpecifyGenericPorts__OutPortGenerics(t *testing.T) {
 	}))
 	a.Equal("boolean", op.Out.Type)
 }
+
+// TODO: Write more tests for OperatorDef.SpecifyGenericPorts(...)
+// TODO: Write tests for PortDef.SpecifyGenericPorts(...)
+// TODO: Write tests for OperatorDef.FreeOfGenerics()
+// TODO: Write tests for PortDef.FreeOfGenerics()
+// TODO: Write tests for PortDef.Copy()

--- a/tests/core_def_test.go
+++ b/tests/core_def_test.go
@@ -8,7 +8,87 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// INSTANCE DEFINITION
+
+func TestInstanceDef_Validate__FailsMissingName(t *testing.T) {
+	a := assertions.New(t)
+	_, err := validateJSONInstanceDef(`{
+		"operator": "opr"
+	}`)
+	a.Error(err)
+}
+
+func TestInstanceDef_Validate__FailsSpacesInName(t *testing.T) {
+	a := assertions.New(t)
+	_, err := validateJSONInstanceDef(`{
+		"operator": "opr",
+		"name":"fun 4 ever",
+	}`)
+	a.Error(err)
+}
+
+func TestInstanceDef_Validate__FailsMissingOperator(t *testing.T) {
+	a := assertions.New(t)
+	_, err := validateJSONInstanceDef(`{
+		"name":"oprInstance"
+	}`)
+	a.Error(err)
+}
+
+func TestInstanceDef_Validate__Succeeds(t *testing.T) {
+	a := assertions.New(t)
+	ins, err := validateJSONInstanceDef(`{
+		"operator": "opr",
+		"name":"oprInstance"
+	}`)
+	a.NoError(err)
+	a.True(ins.Valid())
+}
+
 // OPERATOR DEFINITION
+
+func TestOperatorDef_Validate__FailsPortMustBeDefined_In(t *testing.T) {
+	a := assertions.New(t)
+	_, err := validateJSONOperatorDef(`{
+		"name":"opr",
+		"out": {"type":"number"},
+	}`)
+	a.Error(err)
+}
+
+func TestOperatorDef_Validate__FailsPortMustBeDefined_Out(t *testing.T) {
+	a := assertions.New(t)
+	_, err := validateJSONOperatorDef(`{
+		"name":"opr",
+		"in": {"type":"number"},
+	}`)
+	a.Error(err)
+}
+
+func TestOperatorDef_Validate__Succeeds(t *testing.T) {
+	a := assertions.New(t)
+	oDef, err := validateJSONOperatorDef(`{
+		"name": "opr",
+		"in": {
+			"type": "number"
+		},
+		"out": {
+			"type": "number"
+		},
+		"operators": [
+			{
+				"operator": "builtin_Adder",
+				"name": "add"
+			}
+		],
+		"connections": {
+			":in": ["add:in"],
+			"add:out": [":in"]
+		}
+	}`)
+	a.NoError(err)
+	a.True(oDef.Valid())
+}
 
 func TestOperatorDef_SpecifyGenericPorts__NilGenerics(t *testing.T) {
 	a := assertions.New(t)

--- a/tests/core_def_test.go
+++ b/tests/core_def_test.go
@@ -146,48 +146,48 @@ func TestOperatorDef_SpecifyGenericPorts__DifferentIdentifier(t *testing.T) {
 	a.Equal("generic", op.In.Type)
 }
 
-func TestOperatorDef_FreeOfGenerics__InPortGenerics(t *testing.T) {
+func TestOperatorDef_GenericsSpecified__InPortGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(`{"in": {"type": "generic", "generic": "t1"}, "out": {"type": "number"}}`)
 	require.NoError(t, op.Validate())
-	a.Error(op.FreeOfGenerics())
+	a.Error(op.GenericsSpecified())
 }
 
-func TestOperatorDef_FreeOfGenerics__InPortNoGenerics(t *testing.T) {
+func TestOperatorDef_GenericsSpecified__InPortNoGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(`{"in": {"type": "string"}, "out": {"type": "number"}}`)
 	require.NoError(t, op.Validate())
-	a.NoError(op.FreeOfGenerics())
+	a.NoError(op.GenericsSpecified())
 }
 
-func TestOperatorDef_FreeOfGenerics__OutPortGenerics(t *testing.T) {
+func TestOperatorDef_GenericsSpecified__OutPortGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(`{"in": {"type": "number"}, "out": {"type": "generic", "generic": "t1"}}`)
 	require.NoError(t, op.Validate())
-	a.Error(op.FreeOfGenerics())
+	a.Error(op.GenericsSpecified())
 }
 
-func TestOperatorDef_FreeOfGenerics__OutPortNoGenerics(t *testing.T) {
+func TestOperatorDef_GenericsSpecified__OutPortNoGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(`{"in": {"type": "number"}, "out": {"type": "string"}}`)
 	require.NoError(t, op.Validate())
-	a.NoError(op.FreeOfGenerics())
+	a.NoError(op.GenericsSpecified())
 }
 
-func TestOperatorDef_FreeOfGenerics__GenericPortsGenerics(t *testing.T) {
+func TestOperatorDef_GenericsSpecified__GenericPortsGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(
 		`{"in": {"type": "number"}, "out": {"type": "number"}, "operators": [{"name": "test", "operator": "fork", "generics": {"itemType": {"type": "generic", "generic": "g1"}}}]}`)
 	require.NoError(t, op.Validate())
-	a.Error(op.FreeOfGenerics())
+	a.Error(op.GenericsSpecified())
 }
 
-func TestOperatorDef_FreeOfGenerics__GenericPortsNoGenerics(t *testing.T) {
+func TestOperatorDef_GenericsSpecified__GenericPortsNoGenerics(t *testing.T) {
 	a := assertions.New(t)
 	op := slang.ParseOperatorDef(
 		`{"in": {"type": "number"}, "out": {"type": "number"}, "operators": [{"name": "test", "operator": "fork", "generics": {"itemType": {"type": "number"}}}]}`)
 	require.NoError(t, op.Validate())
-	a.NoError(op.FreeOfGenerics())
+	a.NoError(op.GenericsSpecified())
 }
 
 // PORT DEFINITION
@@ -275,37 +275,37 @@ func TestPortDef_SpecifyGenericPorts__Map(t *testing.T) {
 	a.Equal("number", pd.Map["a"].Type)
 }
 
-func TestPortDef_FreeOfGenerics__SimpleGeneric(t *testing.T) {
+func TestPortDef_GenericsSpecified__SimpleGeneric(t *testing.T) {
 	a := assertions.New(t)
 	pd := core.PortDef{Type: "generic", Generic: "t1"}
 	require.NoError(t, pd.Validate())
-	a.Error(pd.FreeOfGenerics())
+	a.Error(pd.GenericsSpecified())
 }
 
-func TestPortDef_FreeOfGenerics__SimpleNoGeneric(t *testing.T) {
+func TestPortDef_GenericsSpecified__SimpleNoGeneric(t *testing.T) {
 	a := assertions.New(t)
 	pd := core.PortDef{Type: "number"}
 	require.NoError(t, pd.Validate())
-	a.NoError(pd.FreeOfGenerics())
+	a.NoError(pd.GenericsSpecified())
 }
 
-func TestPortDef_FreeOfGenerics__StreamGenerics(t *testing.T) {
+func TestPortDef_GenericsSpecified__StreamGenerics(t *testing.T) {
 	a := assertions.New(t)
 	pd := core.PortDef{Type: "stream", Stream: &core.PortDef{Type: "generic", Generic: "t1"}}
 	require.NoError(t, pd.Validate())
-	a.Error(pd.FreeOfGenerics())
+	a.Error(pd.GenericsSpecified())
 }
 
-func TestPortDef_FreeOfGenerics__StreamNoGenerics(t *testing.T) {
+func TestPortDef_GenericsSpecified__StreamNoGenerics(t *testing.T) {
 	a := assertions.New(t)
 	pd := core.PortDef{Type: "stream", Stream: &core.PortDef{Type: "number"}}
 	require.NoError(t, pd.Validate())
-	a.NoError(pd.FreeOfGenerics())
+	a.NoError(pd.GenericsSpecified())
 }
 
-func TestPortDef_FreeOfGenerics__MapGenerics(t *testing.T) {
+func TestPortDef_GenericsSpecified__MapGenerics(t *testing.T) {
 	a := assertions.New(t)
 	pd := core.PortDef{Type: "map", Map: map[string]*core.PortDef{"a": {Type: "number"}}}
 	require.NoError(t, pd.Validate())
-	a.NoError(pd.FreeOfGenerics())
+	a.NoError(pd.GenericsSpecified())
 }

--- a/tests/core_def_test.go
+++ b/tests/core_def_test.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	"testing"
+	"slang"
+	"slang/tests/assertions"
+	"slang/core"
+)
+
+func TestOperatorDef_SpecifyGenericPorts__NilGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(`{"in": {"type": "number"}, "out": {"type": "number"}}`)
+	a.NoError(op.Validate())
+	a.NoError(op.SpecifyGenericPorts(nil))
+}
+
+func TestOperatorDef_SpecifyGenericPorts__InPortGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(`{"in": {"type": "generic", "generic": "g1"}, "out": {"type": "number"}}`)
+	a.NoError(op.Validate())
+	a.NoError(op.SpecifyGenericPorts(map[string]*core.PortDef{
+		"g1": {
+			Type: "boolean",
+		},
+	}))
+	a.Equal("boolean", op.In.Type)
+}
+
+func TestOperatorDef_SpecifyGenericPorts__OutPortGenerics(t *testing.T) {
+	a := assertions.New(t)
+	op := slang.ParseOperatorDef(`{"in": {"type": "number"}, "out": {"type": "generic", "generic": "g1"}}`)
+	a.NoError(op.Validate())
+	a.NoError(op.SpecifyGenericPorts(map[string]*core.PortDef{
+		"g1": {
+			Type: "boolean",
+		},
+	}))
+	a.Equal("boolean", op.Out.Type)
+}

--- a/tests/core_operator_test.go
+++ b/tests/core_operator_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestOperator_NewOperator_CorrectRelation(t *testing.T) {
+func TestOperator_NewOperator__CorrectRelation(t *testing.T) {
 	defPort := slang.ParsePortDef(`{"type":"number"}`)
 	oParent, _ := core.NewOperator("parent", nil, defPort, defPort)
 	oChild1, _ := core.NewOperator("child1", nil, defPort, defPort)
@@ -23,85 +23,7 @@ func TestOperator_NewOperator_CorrectRelation(t *testing.T) {
 	}
 }
 
-func TestInstanceDef_Validate_Fails_MissingName(t *testing.T) {
-	a := assertions.New(t)
-	_, err := validateJSONInstanceDef(`{
-		"operator": "opr"
-	}`)
-	a.Error(err)
-}
-
-func TestInstanceDef_Validate_Fails_SpacesInName(t *testing.T) {
-	a := assertions.New(t)
-	_, err := validateJSONInstanceDef(`{
-		"operator": "opr",
-		"name":"fun 4 ever",
-	}`)
-	a.Error(err)
-}
-
-func TestInstanceDef_Validate_Fails_MissingOperator(t *testing.T) {
-	a := assertions.New(t)
-	_, err := validateJSONInstanceDef(`{
-		"name":"oprInstance"
-	}`)
-	a.Error(err)
-}
-
-func TestInstanceDef_Validate_Succeeds(t *testing.T) {
-	a := assertions.New(t)
-	ins, err := validateJSONInstanceDef(`{
-		"operator": "opr",
-		"name":"oprInstance"
-	}`)
-	a.NoError(err)
-	a.True(ins.Valid())
-}
-
-func TestOperatorDef_Validate_Fails_PortMustBeDefined_In(t *testing.T) {
-	a := assertions.New(t)
-	_, err := validateJSONOperatorDef(`{
-		"name":"opr",
-		"out": {"type":"number"},
-	}`)
-	a.Error(err)
-}
-
-func TestOperatorDef_Validate_Fails_PortMustBeDefined_Out(t *testing.T) {
-	a := assertions.New(t)
-	_, err := validateJSONOperatorDef(`{
-		"name":"opr",
-		"in": {"type":"number"},
-	}`)
-	a.Error(err)
-}
-
-func TestOperatorDef_Validate_Succeeds(t *testing.T) {
-	a := assertions.New(t)
-	oDef, err := validateJSONOperatorDef(`{
-		"name": "opr",
-		"in": {
-			"type": "number"
-		},
-		"out": {
-			"type": "number"
-		},
-		"operators": [
-			{
-				"operator": "builtin_Adder",
-				"name": "add"
-			}
-		],
-		"connections": {
-			":in": ["add:in"],
-			"add:out": [":in"]
-		}
-	}`)
-	a.NoError(err)
-	a.True(oDef.Valid())
-}
-
-func TestOperator_Compile__Nested_1_Child(t *testing.T) {
+func TestOperator_Compile__Nested1Child(t *testing.T) {
 	a := assertions.New(t)
 	op1, _ := core.NewOperator("", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"})
 	op2, _ := core.NewOperator("a", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"})
@@ -135,7 +57,7 @@ func TestOperator_Compile__Nested_1_Child(t *testing.T) {
 	a.False(op2.Out().Connected(op1.Out()))
 }
 
-func TestOperator_Compile__Nested_Children(t *testing.T) {
+func TestOperator_Compile__NestedChildren(t *testing.T) {
 	a := assertions.New(t)
 	op1, _ := core.NewOperator("", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"})
 	op2, _ := core.NewOperator("a", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"})

--- a/tests/core_port_test.go
+++ b/tests/core_port_test.go
@@ -87,6 +87,20 @@ func TestPortDef_Validate__Map__InvalidTypeInDefinition(t *testing.T) {
 	a.False(def.Valid(), "should not be valid")
 }
 
+func TestPortDef_Validate__Any__IdentifierMissing(t *testing.T) {
+	a := assertions.New(t)
+	def := slang.ParsePortDef(`{"type":"any"}`)
+	a.Error(def.Validate())
+	a.False(def.Valid(), "should not be valid")
+}
+
+func TestPortDef_Validate__Any__Correct(t *testing.T) {
+	a := assertions.New(t)
+	def := slang.ParsePortDef(`{"type":"any", "any":"id1"}`)
+	a.NoError(def.Validate())
+	a.True(def.Valid(), "should be valid")
+}
+
 // core.NewPort (10 tests)
 
 func TestNewPort__InvalidDefinition(t *testing.T) {

--- a/tests/core_port_test.go
+++ b/tests/core_port_test.go
@@ -87,16 +87,16 @@ func TestPortDef_Validate__Map__InvalidTypeInDefinition(t *testing.T) {
 	a.False(def.Valid(), "should not be valid")
 }
 
-func TestPortDef_Validate__Any__IdentifierMissing(t *testing.T) {
+func TestPortDef_Validate__Generic__IdentifierMissing(t *testing.T) {
 	a := assertions.New(t)
-	def := slang.ParsePortDef(`{"type":"any"}`)
+	def := slang.ParsePortDef(`{"type":"generic"}`)
 	a.Error(def.Validate())
 	a.False(def.Valid(), "should not be valid")
 }
 
-func TestPortDef_Validate__Any__Correct(t *testing.T) {
+func TestPortDef_Validate__Generic__Correct(t *testing.T) {
 	a := assertions.New(t)
-	def := slang.ParsePortDef(`{"type":"any", "any":"id1"}`)
+	def := slang.ParsePortDef(`{"type":"generic", "generic":"id1"}`)
 	a.NoError(def.Validate())
 	a.True(def.Valid(), "should be valid")
 }
@@ -213,7 +213,7 @@ func TestNewPort__Complex(t *testing.T) {
 
 // Port.Type (6 tests)
 
-func TestPort_Type__Simple__Any(t *testing.T) {
+func TestPort_Type__Simple__Primitive(t *testing.T) {
 	a := assertions.New(t)
 	def := slang.ParsePortDef(`{"type":"primitive"}`)
 	p, _ := core.NewPort(nil, def, core.DIRECTION_IN)

--- a/tests/slang_test.go
+++ b/tests/slang_test.go
@@ -49,7 +49,7 @@ func TestOperator_ReadOperator_NestedOperator_1_Child(t *testing.T) {
 	a.NoError(err)
 
 	o.Out().Bufferize()
-	o.In().Push(map[string]interface{}{"a": "hallo"})
+	o.In().Push("hallo")
 
 	o.Start()
 
@@ -75,8 +75,8 @@ func TestOperator_ReadOperator_NestedOperator_SubChild(t *testing.T) {
 	a.NoError(err)
 
 	o.Out().Bufferize()
-	o.In().Push(map[string]interface{}{"a": "hallo"})
-	o.In().Push(map[string]interface{}{"a": 2.0})
+	o.In().Push("hallo")
+	o.In().Push(2.0)
 
 	o.Start()
 

--- a/tests/slang_test.go
+++ b/tests/slang_test.go
@@ -5,6 +5,7 @@ import (
 	"slang/core"
 	"slang/tests/assertions"
 	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOperator_ReadOperator_1_OuterOperator(t *testing.T) {
@@ -107,9 +108,10 @@ func TestOperator_ReadOperator__Recursion(t *testing.T) {
 func TestOperator_ReadOperator_NestedGeneric(t *testing.T) {
 	a := assertions.New(t)
 	o, err := slang.BuildOperator("test_data/nested_generic/main.json", false)
-	a.NoError(err)
+	require.NoError(t, err)
 
-	o.Out().Bufferize()
+	o.Out().Map("left").Bufferize()
+	o.Out().Map("right").Bufferize()
 	o.In().Push("hallo")
 
 	a.PortPushes([]interface{}{"hallo"}, o.Out().Map("left"))
@@ -184,7 +186,7 @@ func TestParsePortReference__SingleOut(t *testing.T) {
 func TestParsePortReference__Map(t *testing.T) {
 	a := assertions.New(t)
 	o1, _ := core.NewOperator("o1", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"})
-	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "map", Map: map[string]core.PortDef{"a": {Type: "number"}}}, core.PortDef{Type: "number"})
+	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "map", Map: map[string]*core.PortDef{"a": {Type: "number"}}}, core.PortDef{Type: "number"})
 	o2.SetParent(o1)
 	p, err := slang.ParsePortReference("o2:in.a", o1)
 	a.NoError(err)
@@ -197,7 +199,7 @@ func TestParsePortReference__Map(t *testing.T) {
 func TestParsePortReference__Map__UnknownKey(t *testing.T) {
 	a := assertions.New(t)
 	o1, _ := core.NewOperator("o1", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"})
-	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "map", Map: map[string]core.PortDef{"a": {Type: "number"}}}, core.PortDef{Type: "number"})
+	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "map", Map: map[string]*core.PortDef{"a": {Type: "number"}}}, core.PortDef{Type: "number"})
 	o2.SetParent(o1)
 	p, err := slang.ParsePortReference("o2:in.b", o1)
 	a.Error(err)
@@ -207,7 +209,7 @@ func TestParsePortReference__Map__UnknownKey(t *testing.T) {
 func TestParsePortReference__Map__DescendingTooDeep(t *testing.T) {
 	a := assertions.New(t)
 	o1, _ := core.NewOperator("o1", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"})
-	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "map", Map: map[string]core.PortDef{"a": {Type: "number"}}}, core.PortDef{Type: "number"})
+	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "map", Map: map[string]*core.PortDef{"a": {Type: "number"}}}, core.PortDef{Type: "number"})
 	o2.SetParent(o1)
 	p, err := slang.ParsePortReference("o2:in.b.c", o1)
 	a.Error(err)
@@ -217,7 +219,7 @@ func TestParsePortReference__Map__DescendingTooDeep(t *testing.T) {
 func TestParsePortReference__NestedMap(t *testing.T) {
 	a := assertions.New(t)
 	o1, _ := core.NewOperator("o1", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"})
-	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "map", Map: map[string]core.PortDef{"a": {Type: "map", Map: map[string]core.PortDef{"b": {Type: "number"}}}}}, core.PortDef{Type: "number"})
+	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "map", Map: map[string]*core.PortDef{"a": {Type: "map", Map: map[string]*core.PortDef{"b": {Type: "number"}}}}}, core.PortDef{Type: "number"})
 	o2.SetParent(o1)
 	p, err := slang.ParsePortReference("o2:in.a.b", o1)
 	a.NoError(err)
@@ -248,12 +250,12 @@ func TestParsePortReference__StreamMap(t *testing.T) {
 			Type: "stream",
 			Stream: &core.PortDef{
 				Type: "map",
-				Map: map[string]core.PortDef{
+				Map: map[string]*core.PortDef{
 					"a": {
 						Type: "stream",
 						Stream: &core.PortDef{
 							Type: "map",
-							Map: map[string]core.PortDef{
+							Map: map[string]*core.PortDef{
 								"a": {
 									Type: "stream",
 									Stream: &core.PortDef{

--- a/tests/slang_test.go
+++ b/tests/slang_test.go
@@ -104,6 +104,18 @@ func TestOperator_ReadOperator__Recursion(t *testing.T) {
 	a.Nil(o)
 }
 
+func TestOperator_ReadOperator_NestedGeneric(t *testing.T) {
+	a := assertions.New(t)
+	o, err := slang.BuildOperator("test_data/nested_generic/main.json", false)
+	a.NoError(err)
+
+	o.Out().Bufferize()
+	o.In().Push("hallo")
+
+	a.PortPushes([]interface{}{"hallo"}, o.Out().Map("left"))
+	a.PortPushes([]interface{}{"hallo"}, o.Out().Map("right"))
+}
+
 func TestParsePortReference__NilOperator(t *testing.T) {
 	a := assertions.New(t)
 	p, err := slang.ParsePortReference("test.in", nil)

--- a/tests/test_data/nested_generic/duplicator.json
+++ b/tests/test_data/nested_generic/duplicator.json
@@ -1,0 +1,25 @@
+{
+  "in": {
+    "type": "primitive"
+  },
+  "out": {
+    "type": "map",
+    "map": {
+      "left": {
+        "type": "generic",
+        "generic": "itemType"
+      },
+      "right": {
+        "type": "generic",
+        "generic": "itemType"
+      }
+    }
+  },
+  "operators": [],
+  "connections": {
+    ":in": [
+      ":out.left",
+      ":out.right"
+    ]
+  }
+}

--- a/tests/test_data/nested_generic/main.json
+++ b/tests/test_data/nested_generic/main.json
@@ -1,0 +1,38 @@
+{
+  "in": {
+    "type": "number"
+  },
+  "out": {
+    "type": "map",
+    "map": {
+      "left": {
+        "type": "number"
+      },
+      "right": {
+        "type": "number"
+      }
+    }
+  },
+  "operators": [
+    {
+      "name": "pass1",
+      "operator": ".passer",
+      "generics": {
+        "itemType": {
+          "type": "number"
+        }
+      }
+    }
+  ],
+  "connections": {
+    ":in": [
+      "pass1:in"
+    ],
+    "pass1:out.left": [
+      ":out.left"
+    ],
+    "pass1:out.right": [
+      ":out.right"
+    ]
+  }
+}

--- a/tests/test_data/nested_generic/passer.json
+++ b/tests/test_data/nested_generic/passer.json
@@ -1,0 +1,42 @@
+{
+  "in": {
+    "type": "generic",
+    "generic": "itemType"
+  },
+  "out": {
+    "type": "map",
+    "map": {
+      "left": {
+        "type": "generic",
+        "generic": "itemType"
+      },
+      "right": {
+        "type": "generic",
+        "generic": "itemType"
+      }
+    }
+  },
+  "operators": [
+    {
+      "name": "dupl1",
+      "operator": ".duplicator",
+      "generics": {
+        "itemType": {
+          "type": "generic",
+          "generic": "itemType"
+        }
+      }
+    }
+  ],
+  "connections": {
+    ":in": [
+      "dupl1:in"
+    ],
+    "dupl1:out.left": [
+      ":out.left"
+    ],
+    "dupl1:out.right": [
+      ":out.right"
+    ]
+  }
+}

--- a/tests/test_data/nested_op/customOp.json
+++ b/tests/test_data/nested_op/customOp.json
@@ -13,7 +13,7 @@
       "properties": {
         "expression": "a"
       },
-      "ports": {
+      "generics": {
         "paramsMap": {
           "type": "map",
           "map": {

--- a/tests/test_data/nested_op/customOp.json
+++ b/tests/test_data/nested_op/customOp.json
@@ -12,12 +12,22 @@
       "name": "passer",
       "properties": {
         "expression": "a"
+      },
+      "ports": {
+        "paramsMap": {
+          "type": "map",
+          "map": {
+            "a": {
+              "type": "primitive"
+            }
+          }
+        }
       }
     }
   ],
   "connections": {
     ":in": [
-      "passer:in"
+      "passer:in.a"
     ],
     "passer:out": [
       ":out"

--- a/tests/test_data/nested_op/sub/customOpDouble.json
+++ b/tests/test_data/nested_op/sub/customOpDouble.json
@@ -12,7 +12,7 @@
       "properties": {
         "expression": "a+a"
       },
-      "ports": {
+      "generics": {
         "paramsMap": {
           "type": "map",
           "map": {

--- a/tests/test_data/nested_op/sub/customOpDouble.json
+++ b/tests/test_data/nested_op/sub/customOpDouble.json
@@ -12,20 +12,21 @@
       "properties": {
         "expression": "a+a"
       },
-      "in": {
-        "type": "map",
-        "map": {
-          "a": {"type": "number"}
+      "ports": {
+        "paramsMap": {
+          "type": "map",
+          "map": {
+            "a": {
+              "type": "number"
+            }
+          }
         }
-      },
-      "out": {
-        "type": "number"
       }
     }
   ],
   "connections": {
     ":in": [
-      "doubler:in"
+      "doubler:in.a"
     ],
     "doubler:out": [
       ":out"

--- a/tests/test_data/nested_op/usingSubCustomOpDouble_test.json
+++ b/tests/test_data/nested_op/usingSubCustomOpDouble_test.json
@@ -7,9 +7,9 @@
       "description": "Numbers must be doubled",
       "data": {
         "in": [
-          {"a": 1},
-          {"a": 7.5},
-          {"a": 0}
+          1,
+          7.5,
+          0
         ],
         "out": [
           2,
@@ -23,8 +23,8 @@
       "description": "Strings must be doubled",
       "data": {
         "in": [
-          {"a": "hello"},
-          {"a": "slang"}
+          "hello",
+          "slang"
         ],
         "out": [
           "hellohello",

--- a/tests/test_data/suite/duplicator.json
+++ b/tests/test_data/suite/duplicator.json
@@ -6,10 +6,12 @@
     "type": "map",
     "map": {
       "left": {
-        "type": "primitive"
+        "type": "any",
+        "any": "itemType"
       },
       "right": {
-        "type": "primitive"
+        "type": "any",
+        "any": "itemType"
       }
     }
   },

--- a/tests/test_data/suite/duplicator.json
+++ b/tests/test_data/suite/duplicator.json
@@ -6,12 +6,12 @@
     "type": "map",
     "map": {
       "left": {
-        "type": "any",
-        "any": "itemType"
+        "type": "generic",
+        "generic": "itemType"
       },
       "right": {
-        "type": "any",
-        "any": "itemType"
+        "type": "generic",
+        "generic": "itemType"
       }
     }
   },

--- a/tests/test_data/suite/main.json
+++ b/tests/test_data/suite/main.json
@@ -20,7 +20,7 @@
     {
       "name": "dbl1",
       "operator": ".duplicator",
-      "ports": {
+      "generics": {
         "itemType": {
           "type": "number"
         }
@@ -29,7 +29,7 @@
     {
       "name": "dbl2",
       "operator": ".duplicator",
-      "ports": {
+      "generics": {
         "itemType": {
           "type": "number"
         }
@@ -38,7 +38,7 @@
     {
       "name": "dbl3",
       "operator": ".duplicator",
-      "ports": {
+      "generics": {
         "itemType": {
           "type": "number"
         }
@@ -47,7 +47,7 @@
     {
       "name": "tl",
       "operator": ".takers.takeLeft",
-      "ports": {
+      "generics": {
         "itemType": {
           "type": "number"
         }
@@ -56,7 +56,7 @@
     {
       "name": "tr",
       "operator": ".takers.takeRight",
-      "ports": {
+      "generics": {
         "itemType": {
           "type": "number"
         }

--- a/tests/test_data/suite/main.json
+++ b/tests/test_data/suite/main.json
@@ -19,23 +19,48 @@
   "operators": [
     {
       "name": "dbl1",
-      "operator": ".duplicator"
+      "operator": ".duplicator",
+      "ports": {
+        "itemType": {
+          "type": "number"
+        }
+      }
     },
     {
       "name": "dbl2",
-      "operator": ".duplicator"
+      "operator": ".duplicator",
+      "ports": {
+        "itemType": {
+          "type": "number"
+        }
+      }
     },
     {
       "name": "dbl3",
-      "operator": ".duplicator"
+      "operator": ".duplicator",
+      "ports": {
+        "itemType": {
+          "type": "number"
+        }
+      }
     },
     {
       "name": "tl",
-      "operator": ".takers.takeLeft"
+      "operator": ".takers.takeLeft",
+      "ports": {
+        "itemType": {
+          "type": "number"
+        }
+      }
     },
     {
       "name": "tr",
-      "operator": ".takers.takeRight"
+      "operator": ".takers.takeRight",
+      "ports": {
+        "itemType": {
+          "type": "number"
+        }
+      }
     },
     {
       "name": "p",

--- a/tests/test_data/suite/polynomial.json
+++ b/tests/test_data/suite/polynomial.json
@@ -26,7 +26,7 @@
       "properties": {
         "expression": "a*x*x + b*x + c"
       },
-      "ports": {
+      "generics": {
         "paramsMap": {
           "type": "map",
           "map": {

--- a/tests/test_data/suite/polynomial.json
+++ b/tests/test_data/suite/polynomial.json
@@ -26,17 +26,24 @@
       "properties": {
         "expression": "a*x*x + b*x + c"
       },
-      "in": {
-        "type": "map",
-        "map": {
-          "a": {"type": "number"},
-          "b": {"type": "number"},
-          "c": {"type": "number"},
-          "x": {"type": "number"}
+      "ports": {
+        "paramsMap": {
+          "type": "map",
+          "map": {
+            "a": {
+              "type": "number"
+            },
+            "b": {
+              "type": "number"
+            },
+            "c": {
+              "type": "number"
+            },
+            "x": {
+              "type": "number"
+            }
+          }
         }
-      },
-      "out": {
-        "type": "number"
       }
     }
   ],

--- a/tests/test_data/suite/takers/takeLeft.json
+++ b/tests/test_data/suite/takers/takeLeft.json
@@ -3,18 +3,23 @@
     "type": "map",
     "map": {
       "left": {
-        "type": "primitive"
+        "type": "any",
+        "any": "itemType"
       },
       "right": {
-        "type": "primitive"
+        "type": "any",
+        "any": "itemType"
       }
     }
   },
   "out": {
-    "type": "primitive"
+    "type": "any",
+    "any": "itemType"
   },
   "operators": [],
   "connections": {
-    ":in.left": [":out"]
+    ":in.left": [
+      ":out"
+    ]
   }
 }

--- a/tests/test_data/suite/takers/takeLeft.json
+++ b/tests/test_data/suite/takers/takeLeft.json
@@ -3,18 +3,18 @@
     "type": "map",
     "map": {
       "left": {
-        "type": "any",
-        "any": "itemType"
+        "type": "generic",
+        "generic": "itemType"
       },
       "right": {
-        "type": "any",
-        "any": "itemType"
+        "type": "generic",
+        "generic": "itemType"
       }
     }
   },
   "out": {
-    "type": "any",
-    "any": "itemType"
+    "type": "generic",
+    "generic": "itemType"
   },
   "operators": [],
   "connections": {

--- a/tests/test_data/suite/takers/takeRight.json
+++ b/tests/test_data/suite/takers/takeRight.json
@@ -3,18 +3,23 @@
     "type": "map",
     "map": {
       "left": {
-        "type": "primitive"
+        "type": "any",
+        "any": "itemType"
       },
       "right": {
-        "type": "primitive"
+        "type": "any",
+        "any": "itemType"
       }
     }
   },
   "out": {
-    "type": "primitive"
+    "type": "any",
+    "any": "itemType"
   },
   "operators": [],
   "connections": {
-    ":in.right": [":out"]
+    ":in.right": [
+      ":out"
+    ]
   }
 }

--- a/tests/test_data/suite/takers/takeRight.json
+++ b/tests/test_data/suite/takers/takeRight.json
@@ -3,18 +3,18 @@
     "type": "map",
     "map": {
       "left": {
-        "type": "any",
-        "any": "itemType"
+        "type": "generic",
+        "generic": "itemType"
       },
       "right": {
-        "type": "any",
-        "any": "itemType"
+        "type": "generic",
+        "generic": "itemType"
       }
     }
   },
   "out": {
-    "type": "any",
-    "any": "itemType"
+    "type": "generic",
+    "generic": "itemType"
   },
   "operators": [],
   "connections": {

--- a/tests/test_data/usingBuiltinOp.json
+++ b/tests/test_data/usingBuiltinOp.json
@@ -12,6 +12,16 @@
       "name": "passer",
       "properties": {
         "expression": "a"
+      },
+      "ports": {
+        "paramsMap": {
+          "type": "map",
+          "map": {
+            "a": {
+              "type": "primitive"
+            }
+          }
+        }
       }
     }
   ],

--- a/tests/test_data/usingBuiltinOp.json
+++ b/tests/test_data/usingBuiltinOp.json
@@ -13,7 +13,7 @@
       "properties": {
         "expression": "a"
       },
-      "ports": {
+      "generics": {
         "paramsMap": {
           "type": "map",
           "map": {

--- a/tests/test_test.go
+++ b/tests/test_test.go
@@ -31,7 +31,7 @@ func TestTestOperator__ComplexTest(t *testing.T) {
 	a.Equal(0, fails)
 }
 
-/*func TestTestOperator__SuiteTests(t *testing.T) {
+func TestTestOperator__SuiteTests(t *testing.T) {
 	a := assertions.New(t)
 
 	succs, fails, err := slang.TestOperator("test_data/suite/polynomial_test.json", ioutil.Discard, false)
@@ -39,8 +39,8 @@ func TestTestOperator__ComplexTest(t *testing.T) {
 	a.Equal(1, succs)
 	a.Equal(0, fails)
 
-	succs, fails, err = slang.TestOperator("test_data/suite/main_test.json", ioutil.Discard, false)
+	/*succs, fails, err = slang.TestOperator("test_data/suite/main_test.json", ioutil.Discard, false)
 	a.Nil(err)
 	a.Equal(2, succs)
-	a.Equal(0, fails)
-}*/
+	a.Equal(0, fails)*/
+}

--- a/tests/test_test.go
+++ b/tests/test_test.go
@@ -39,8 +39,8 @@ func TestTestOperator__SuiteTests(t *testing.T) {
 	a.Equal(1, succs)
 	a.Equal(0, fails)
 
-	/*succs, fails, err = slang.TestOperator("test_data/suite/main_test.json", ioutil.Discard, false)
+	succs, fails, err = slang.TestOperator("test_data/suite/main_test.json", ioutil.Discard, false)
 	a.Nil(err)
 	a.Equal(2, succs)
-	a.Equal(0, fails)*/
+	a.Equal(0, fails)
 }


### PR DESCRIPTION
This PR does *not* implement type inference. Rather, it adds the possibility to specify a placeholder type (called `generic`) in the ports definitions. When instancing such an operator, you have to specify the type in the `generics` field of an instance. This introduces generic operators.

It also makes run the old tests and is fully compatible with the builtin operators.

Tests run successfully of course (including the complex suits test).

What still needs to be done:
- [x] Write tests
- [x] Add explanatory  comments
- [x] Review *thoroughly*
  
Closes #38 #49 