### PR TITLE
Fix order in which operators are being connected

### DIFF
--- a/core/port.go
+++ b/core/port.go
@@ -116,6 +116,11 @@ func (p *Port) ParentStream() *Port {
 	return p.parStr
 }
 
+// Returns the operator this port is attached to
+func (p *Port) Operator() *Operator {
+	return p.operator
+}
+
 // Returns the subport with the according name of this port. Port must be of type map.
 func (p *Port) Map(name string) *Port {
 	port, _ := p.subs[name]

--- a/slang.go
+++ b/slang.go
@@ -63,19 +63,19 @@ func ParseYAMLOperatorDef(defStr string) (core.OperatorDef, error) {
 	return def, err
 }
 
-func ParsePortReference(connStr string, par *core.Operator) (*core.Port, error) {
+func ParsePortReference(refStr string, par *core.Operator) (*core.Port, error) {
 	if par == nil {
 		return nil, errors.New("operator must not be nil")
 	}
 
-	if len(connStr) == 0 {
+	if len(refStr) == 0 {
 		return nil, errors.New("empty connection string")
 	}
 
-	opSplit := strings.Split(connStr, ":")
+	opSplit := strings.Split(refStr, ":")
 
 	if len(opSplit) != 2 {
-		return nil, errors.New("connection string malformed")
+		return nil, fmt.Errorf(`connection string malformed: ""%s"`, refStr)
 	}
 
 	var o *core.Operator
@@ -91,7 +91,7 @@ func ParsePortReference(connStr string, par *core.Operator) (*core.Port, error) 
 	pathSplit := strings.Split(opSplit[1], ".")
 
 	if len(pathSplit) == 0 {
-		return nil, errors.New("connection string malformed")
+		return nil, fmt.Errorf(`connection string malformed: ""%s"`, refStr)
 	}
 
 	var p *core.Port
@@ -293,14 +293,14 @@ func buildAndConnectOperator(insName string, def core.OperatorDef, par *core.Ope
 		}
 	}
 
-	// After having created all operators, connect all operators from bottom to top
+	// Parse all connections before starting to connect
+	parsedConns := make(map[*core.Port][]*core.Port)
 	for srcConnDef, dstConnDefs := range def.Connections {
 		if pSrc, err := ParsePortReference(srcConnDef, o); err == nil {
+			parsedConns[pSrc] = nil
 			for _, dstConnDef := range dstConnDefs {
 				if pDst, err := ParsePortReference(dstConnDef, o); err == nil {
-					if err := pSrc.Connect(pDst); err != nil {
-						return nil, err
-					}
+					parsedConns[pSrc] = append(parsedConns[pSrc], pDst)
 				} else {
 					return nil, err
 				}
@@ -310,7 +310,32 @@ func buildAndConnectOperator(insName string, def core.OperatorDef, par *core.Ope
 		}
 	}
 
+	if err := connectDestinations(o, parsedConns); err != nil {
+		return nil, err
+	}
+
 	return o, nil
+}
+
+// connectDestinations connects operators following from the in port to the out port
+func connectDestinations(o *core.Operator, conns map[*core.Port][]*core.Port) error {
+	for pSrc, pDsts := range conns {
+		if pSrc.Operator() == o {
+			var ops []*core.Operator
+			for _, pDst := range pDsts {
+				if err := pSrc.Connect(pDst); err != nil {
+					return err
+				}
+				ops = append(ops, pDst.Operator())
+			}
+			// Set the destinations nil so that we do not end in an infinite recursion
+			conns[pSrc] = nil
+			for _, op := range ops {
+				connectDestinations(op, conns)
+			}
+		}
+	}
+	return nil
 }
 
 // getOperator creates and returns an operator according to the instance definition. If there exists a suitable


### PR DESCRIPTION
Ensures that ports are being connected from the in to the out port and not in an arbitrary order.
This is particularly important for the `connect` methods which relies on that basePort is already set (`q.operator.basePort = p.operator.basePort`).