### PR TITLE
Fix testEqual method

### DIFF
--- a/test.go
+++ b/test.go
@@ -165,10 +165,31 @@ func testEqual(a, b interface{}) bool {
 		return true
 	}
 
+	am, aok := a.(map[string]interface{})
+	bm, bok := b.(map[string]interface{})
+
+	if aok && bok {
+		if len(am) != len(bm) {
+			return false
+		}
+
+		for k, ai := range am {
+			if bi, ok := bm[k]; ok {
+				if !testEqual(ai, bi) {
+					return false
+				}
+			} else {
+				return false
+			}
+		}
+
+		return true
+	}
+
 	if ai, ok := a.(int); ok {
 		a = float64(ai)
 	}
-	if bi, ok := a.(int); ok {
+	if bi, ok := b.(int); ok {
 		b = float64(bi)
 	}
 	return reflect.DeepEqual(a, b)

--- a/test_test.go
+++ b/test_test.go
@@ -1,0 +1,59 @@
+package slang
+
+import (
+	"testing"
+	"slang/tests/assertions"
+)
+
+func TestTestEqual__Bools(t *testing.T) {
+	a := assertions.New(t)
+	a.True(testEqual(true, true))
+	a.True(testEqual(false, false))
+	a.False(testEqual(true, false))
+	a.False(testEqual(false, true))
+}
+
+func TestTestEqual__Strings(t *testing.T) {
+	a := assertions.New(t)
+	a.False(testEqual("", nil))
+	a.False(testEqual("", "test"))
+	a.True(testEqual("", ""))
+	a.True(testEqual("test", "test"))
+}
+
+func TestTestEqual__Number(t *testing.T) {
+	a := assertions.New(t)
+	a.False(testEqual(1, 0))
+	a.False(testEqual(1.0, 0))
+	a.False(testEqual(1, 0.0))
+	a.False(testEqual(1.0, 0.0))
+
+	a.True(testEqual(1, 1))
+	a.True(testEqual(0, 0))
+	a.True(testEqual(1.0, 1))
+	a.True(testEqual(0.0, 0))
+	a.True(testEqual(1, 1.0))
+	a.True(testEqual(0, 0.0))
+	a.True(testEqual(1.0, 1.0))
+	a.True(testEqual(0.0, 0.0))
+}
+
+func TestTestEqual__Streams(t *testing.T) {
+	a := assertions.New(t)
+	a.False(testEqual([]interface{}{1}, []interface{}{0}))
+	a.True(testEqual([]interface{}{1}, []interface{}{1}))
+	a.True(testEqual([]interface{}{1.0}, []interface{}{1}))
+	a.False(testEqual([]interface{}{1, 2}, []interface{}{1}))
+	a.False(testEqual([]interface{}{1}, []interface{}{1, 2}))
+}
+
+func TestTestEqual__Maps(t *testing.T) {
+	a := assertions.New(t)
+	a.True(testEqual(map[string]interface{}{"a": true}, map[string]interface{}{"a": true}))
+	a.False(testEqual(map[string]interface{}{"a": true, "b": true}, map[string]interface{}{"a": true}))
+	a.False(testEqual(map[string]interface{}{"a": true}, map[string]interface{}{"a": true, "b": true}))
+
+	a.False(testEqual(map[string]interface{}{"a": true}, map[string]interface{}{"a": false}))
+	a.True(testEqual(map[string]interface{}{"a": 1}, map[string]interface{}{"a": 1}))
+	a.True(testEqual(map[string]interface{}{"a": 1}, map[string]interface{}{"a": 1.0}))
+}


### PR DESCRIPTION
The `testEqual` method contained a bug not converting `b` (see code).

This PR also contains an implementation for testing of equality of maps.

There are some tests attached which are in the root directory because `testEqual` is a package internal method. Since we wanted to move tests out of the `test` directory anyway I think this is OK.