### PR TITLE
Sync controls

### DIFF
--- a/builtin/manager.go
+++ b/builtin/manager.go
@@ -90,6 +90,8 @@ func init() {
 	Register("take", takeOpCfg)
 	Register("agg", aggOpCfg)
 	Register("reduce", reduceOpCfg)
+	Register("syncFork", syncForkOpCfg)
+	Register("syncMerge", syncMergeOpCfg)
 }
 
 func getBuiltinCfg(name string) *builtinConfig {

--- a/builtin/sync_fork.go
+++ b/builtin/sync_fork.go
@@ -9,7 +9,7 @@ var syncForkOpCfg = &builtinConfig{
 		In: core.PortDef{
 			Type: "map",
 			Map: map[string]*core.PortDef{
-				"i": {
+				"item": {
 					Type:    "generic",
 					Generic: "itemType",
 				},
@@ -41,11 +41,11 @@ var syncForkOpCfg = &builtinConfig{
 			}
 
 			if item["select"].(bool) {
-				out.Map("true").Push(item["i"])
+				out.Map("true").Push(item["item"])
 				out.Map("false").Push(nil)
 			} else {
 				out.Map("true").Push(nil)
-				out.Map("false").Push(item["i"])
+				out.Map("false").Push(item["item"])
 			}
 		}
 	},

--- a/builtin/sync_fork.go
+++ b/builtin/sync_fork.go
@@ -1,0 +1,52 @@
+package builtin
+
+import (
+	"slang/core"
+)
+
+var syncForkOpCfg = &builtinConfig{
+	oDef: core.OperatorDef{
+		In: core.PortDef{
+			Type: "map",
+			Map: map[string]*core.PortDef{
+				"i": {
+					Type:    "generic",
+					Generic: "itemType",
+				},
+				"select": {
+					Type: "boolean",
+				},
+			},
+		},
+		Out: core.PortDef{
+			Type: "map",
+			Map: map[string]*core.PortDef{
+				"true": {
+					Type:    "generic",
+					Generic: "itemType",
+				},
+				"false": {
+					Type:    "generic",
+					Generic: "itemType",
+				},
+			},
+		},
+	},
+	oFunc: func(in, out *core.Port, store interface{}) {
+		for true {
+			item, ok := in.Pull().(map[string]interface{})
+			if !ok {
+				out.Push(item)
+				continue
+			}
+
+			if item["select"].(bool) {
+				out.Map("true").Push(item["i"])
+				out.Map("false").Push(nil)
+			} else {
+				out.Map("true").Push(nil)
+				out.Map("false").Push(item["i"])
+			}
+		}
+	},
+}

--- a/builtin/sync_fork_test.go
+++ b/builtin/sync_fork_test.go
@@ -1,0 +1,136 @@
+package builtin
+
+import (
+	"github.com/stretchr/testify/require"
+	"slang/core"
+	"slang/tests/assertions"
+	"testing"
+)
+
+func TestBuiltin_SyncFork__CreatorFuncIsRegistered(t *testing.T) {
+	a := assertions.New(t)
+
+	ocFork := getBuiltinCfg("syncFork")
+	a.NotNil(ocFork)
+}
+
+func TestBuiltin_SyncFork__InPorts(t *testing.T) {
+	a := assertions.New(t)
+
+	o, err := MakeOperator(
+		core.InstanceDef{
+			Operator: "syncFork",
+			Generics: map[string]*core.PortDef{
+				"itemType": {
+					Type: "primitive",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	a.NotNil(o.In().Map("item"))
+	a.NotNil(o.In().Map("select"))
+	a.Equal(core.TYPE_PRIMITIVE, o.In().Map("item").Type())
+	a.Equal(core.TYPE_BOOLEAN, o.In().Map("select").Type())
+}
+
+func TestBuiltin_SyncFork__OutPorts(t *testing.T) {
+	a := assertions.New(t)
+
+	o, err := MakeOperator(
+		core.InstanceDef{
+			Operator: "syncFork",
+			Generics: map[string]*core.PortDef{
+				"itemType": {
+					Type: "primitive",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	a.NotNil(o.Out().Map("true"))
+	a.NotNil(o.Out().Map("false"))
+	a.Equal(core.TYPE_PRIMITIVE, o.Out().Map("true").Type())
+	a.Equal(core.TYPE_PRIMITIVE, o.Out().Map("false").Type())
+}
+
+func TestBuiltin_SyncFork__Correct(t *testing.T) {
+	a := assertions.New(t)
+
+	o, err := MakeOperator(
+		core.InstanceDef{
+			Operator: "syncFork",
+			Generics: map[string]*core.PortDef{
+				"itemType": {
+					Type: "primitive",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	o.Out().Bufferize()
+	o.Start()
+
+	o.In().Push(
+		map[string]interface{}{
+			"item":   "hallo",
+			"select": true,
+		})
+	o.In().Push(
+		map[string]interface{}{
+			"item":   "welt",
+			"select": false,
+		})
+	o.In().Push(
+		map[string]interface{}{
+			"item":   100,
+			"select": true,
+		})
+	o.In().Push(
+		map[string]interface{}{
+			"item":   101,
+			"select": false,
+		})
+
+	a.PortPushes([]interface{}{"hallo", nil, 100, nil}, o.Out().Map("true"))
+	a.PortPushes([]interface{}{nil, "welt", nil, 101}, o.Out().Map("false"))
+}
+
+func TestBuiltin_SyncFork__ComplexItems(t *testing.T) {
+	a := assertions.New(t)
+	o, err := MakeOperator(
+		core.InstanceDef{
+			Operator: "syncFork",
+			Generics: map[string]*core.PortDef{
+				"itemType": {
+					Type: "map",
+					Map: map[string]*core.PortDef{
+						"a": {Type: "number"},
+						"b": {Type: "string"},
+					},
+				},
+			},
+		},
+	)
+	a.NoError(err)
+
+	o.Out().Bufferize()
+	o.Start()
+
+	o.In().Push(
+		map[string]interface{}{
+			"item":   map[string]interface{}{"a": "1", "b": "hallo"},
+			"select": true,
+		})
+	o.In().Push(
+		map[string]interface{}{
+			"item":   map[string]interface{}{"a": "2", "b": "slang"},
+			"select": false,
+		})
+
+	a.PortPushes([]interface{}{map[string]interface{}{"a": "1", "b": "hallo"}, map[string]interface{}{"a": nil, "b": nil}}, o.Out().Map("true"))
+	a.PortPushes([]interface{}{map[string]interface{}{"a": nil, "b": nil}, map[string]interface{}{"a": "2", "b": "slang"}}, o.Out().Map("false"))
+}

--- a/builtin/sync_merge.go
+++ b/builtin/sync_merge.go
@@ -1,0 +1,45 @@
+package builtin
+
+import (
+	"slang/core"
+)
+
+var syncMergeOpCfg = &builtinConfig{
+	oDef: core.OperatorDef{
+		In: core.PortDef{
+			Type: "map",
+			Map: map[string]*core.PortDef{
+				"true": {
+					Type:    "generic",
+					Generic: "itemType",
+				},
+				"false": {
+					Type:    "generic",
+					Generic: "itemType",
+				},
+				"select": {
+					Type: "boolean",
+				},
+			},
+		},
+		Out: core.PortDef{
+			Type:    "generic",
+			Generic: "itemType",
+		},
+	},
+	oFunc: func(in, out *core.Port, store interface{}) {
+		for true {
+			item, ok := in.Pull().(map[string]interface{})
+			if !ok {
+				out.Push(item)
+				continue
+			}
+
+			if item["select"].(bool) {
+				out.Push(item["true"])
+			} else {
+				out.Push(item["false"])
+			}
+		}
+	},
+}

--- a/builtin/sync_merge_test.go
+++ b/builtin/sync_merge_test.go
@@ -1,0 +1,114 @@
+package builtin
+
+import (
+	"github.com/stretchr/testify/require"
+	"slang/core"
+	"slang/tests/assertions"
+	"testing"
+)
+
+func TestBuiltin_SyncMerge__CreatorFuncIsRegistered(t *testing.T) {
+	a := assertions.New(t)
+
+	ocFork := getBuiltinCfg("syncMerge")
+	a.NotNil(ocFork)
+}
+
+func TestBuiltin_SyncMerge__InPorts(t *testing.T) {
+	a := assertions.New(t)
+
+	o, err := MakeOperator(core.InstanceDef{Operator: "syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	require.NoError(t, err)
+
+	a.NotNil(o.In().Map("true"))
+	a.NotNil(o.In().Map("false"))
+	a.NotNil(o.In().Map("select"))
+	a.Equal(core.TYPE_PRIMITIVE, o.In().Map("true").Type())
+	a.Equal(core.TYPE_PRIMITIVE, o.In().Map("false").Type())
+	a.Equal(core.TYPE_BOOLEAN, o.In().Map("select").Type())
+}
+
+func TestBuiltin_SyncMerge__OutPorts(t *testing.T) {
+	a := assertions.New(t)
+
+	o, err := MakeOperator(core.InstanceDef{Operator: "syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	require.NoError(t, err)
+
+	a.NotNil(o.Out())
+	a.Equal(core.TYPE_PRIMITIVE, o.Out().Type())
+}
+
+func TestBuiltin_SyncMerge__Works(t *testing.T) {
+	a := assertions.New(t)
+
+	o, err := MakeOperator(core.InstanceDef{Operator: "syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	require.NoError(t, err)
+
+	o.Out().Bufferize()
+	o.Start()
+
+	trues := []interface{}{"Roses", 6, false, "Violets", "are", nil, 1, 2, nil, 4}
+	falses := []interface{}{nil, "are", "red.", nil, nil, "blue.", "test", nil, 3, nil}
+	selects := []interface{}{true, false, false, true, true, false, true, true, false, true}
+
+	for _, v := range trues {
+		o.In().Map("true").Push(v)
+	}
+	for _, v := range falses {
+		o.In().Map("false").Push(v)
+	}
+	for _, v := range selects {
+		o.In().Map("select").Push(v)
+	}
+
+	a.PortPushes([]interface{}{"Roses", "are", "red.", "Violets", "are", "blue.", 1, 2, 3, 4}, o.Out())
+}
+
+func TestBuiltin_SyncMerge__ComplexItems(t *testing.T) {
+	a := assertions.New(t)
+	o, err := MakeOperator(core.InstanceDef{
+		Operator: "syncMerge",
+		Generics: map[string]*core.PortDef{"itemType": {Type: "map", Map: map[string]*core.PortDef{"red": {Type: "string"}, "blue": {Type: "string"}}}},
+	})
+	require.NoError(t, err)
+
+	o.Out().Bufferize()
+	o.Start()
+
+	trues := []interface{}{
+		[]interface{}{},
+		map[string]interface{}{
+			"red":  "Roses",
+			"blue": "Violets",
+		},
+		map[string]interface{}{
+			"red":  "Apples",
+			"blue": "Blueberries",
+		},
+	}
+	falses := []interface{}{
+		map[string]interface{}{
+			"red":  "Red Bull",
+			"blue": "Blues",
+		},
+		nil,
+		42,
+	}
+	selects := []interface{}{false, true, true}
+
+	for _, v := range trues {
+		o.In().Map("true").Push(v)
+	}
+	for _, v := range falses {
+		o.In().Map("false").Push(v)
+	}
+	for _, v := range selects {
+		o.In().Map("select").Push(v)
+	}
+
+	a.PortPushes([]interface{}{
+		map[string]interface{}{"red": "Red Bull", "blue": "Blues"},
+		map[string]interface{}{"red": "Roses", "blue": "Violets"},
+		map[string]interface{}{"red": "Apples", "blue": "Blueberries"},
+	}, o.Out())
+}


### PR DESCRIPTION
This PR contains two additional operators which are probably not implementable with current builtins:
* syncMerge
* syncFork

They behave like `merge` and `fork` but have a different signature not involving streams at all and make use of `nil` values.

You need `syncMerge` if you get two values and want to take only one of them and throw the other away depending on a `select` value.

`syncFork` is the natural complement.