### PR TITLE
Register builtin operators under library-like name

### DIFF
--- a/builtin/aggregate.go
+++ b/builtin/aggregate.go
@@ -4,7 +4,7 @@ import (
 	"slang/core"
 )
 
-var aggOpCfg = &builtinConfig{
+var aggregateOpCfg = &builtinConfig{
 	oDef: core.OperatorDef{
 		In: core.PortDef{
 			Type: "map",

--- a/builtin/aggregate_test.go
+++ b/builtin/aggregate_test.go
@@ -7,18 +7,18 @@ import (
 	"testing"
 )
 
-func TestOperatorCreator__Agg__IsRegistered(t *testing.T) {
+func TestOperatorCreator__Aggregate__IsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocAgg := getBuiltinCfg("agg")
+	ocAgg := getBuiltinCfg("slang.aggregate")
 	a.NotNil(ocAgg)
 }
 
-func TestBuiltinAgg__PassOtherMarkers(t *testing.T) {
+func TestBuiltinAggregate__PassOtherMarkers(t *testing.T) {
 	a := assertions.New(t)
 	ao, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "agg",
+			Operator: "slang.aggregate",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "number",
@@ -62,11 +62,11 @@ func TestBuiltinAgg__PassOtherMarkers(t *testing.T) {
 	a.PortPushes([]interface{}{[]interface{}{0.0}}, do.Out())
 }
 
-func TestBuiltinAgg__SimpleLoop(t *testing.T) {
+func TestBuiltinAggregate__SimpleLoop(t *testing.T) {
 	a := assertions.New(t)
 	ao, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "agg",
+			Operator: "slang.aggregate",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "number",

--- a/builtin/const_test.go
+++ b/builtin/const_test.go
@@ -10,7 +10,7 @@ import (
 func TestOperatorConst__IsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocConst := getBuiltinCfg("const")
+	ocConst := getBuiltinCfg("slang.const")
 	a.NotNil(ocConst)
 }
 
@@ -46,7 +46,7 @@ func TestBuiltinConst__Correct(t *testing.T) {
 	a := assertions.New(t)
 	ao, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "const",
+			Operator: "slang.const",
 			Generics: map[string]*core.PortDef{
 				"valueType": {
 					Type: "number",
@@ -66,7 +66,7 @@ func TestBuiltinConst__PushBoolean(t *testing.T) {
 	a := assertions.New(t)
 	ao, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "const",
+			Operator: "slang.const",
 			Generics: map[string]*core.PortDef{
 				"valueType": {
 					Type: "boolean",
@@ -96,7 +96,7 @@ func TestBuiltinConst__PushStream(t *testing.T) {
 	a := assertions.New(t)
 	ao, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "const",
+			Operator: "slang.const",
 			Generics: map[string]*core.PortDef{
 				"valueType": {
 					Type: "stream",
@@ -130,7 +130,7 @@ func TestBuiltinConst__PushMap(t *testing.T) {
 	a := assertions.New(t)
 	ao, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "const",
+			Operator: "slang.const",
 			Generics: map[string]*core.PortDef{
 				"valueType": {
 					Type: "map",
@@ -169,7 +169,7 @@ func TestOperatorConst__SimpleNumber(t *testing.T) {
 	a := assertions.New(t)
 	co, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "const",
+			Operator: "slang.const",
 			Generics: map[string]*core.PortDef{
 				"valueType": {
 					Type: "number",
@@ -194,7 +194,7 @@ func TestOperatorConst__ComplexStreamMap(t *testing.T) {
 	a := assertions.New(t)
 	co, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "const",
+			Operator: "slang.const",
 			Generics: map[string]*core.PortDef{
 				"valueType": {
 					Type: "map",
@@ -231,7 +231,7 @@ func TestOperatorConst__PassMarkers(t *testing.T) {
 	a := assertions.New(t)
 	co, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "const",
+			Operator: "slang.const",
 			Generics: map[string]*core.PortDef{
 				"valueType": {
 					Type: "number",

--- a/builtin/eval_test.go
+++ b/builtin/eval_test.go
@@ -243,31 +243,31 @@ func TestFlatMapParameters__ComplexMixed(t *testing.T) {
 
 func TestBuiltin_Eval__IsRegistered(t *testing.T) {
 	a := assertions.New(t)
-	a.True(IsRegistered("eval"))
+	a.True(IsRegistered("slang.eval"))
 }
 
 func TestBuiltin_Eval__NilProperties(t *testing.T) {
 	a := assertions.New(t)
-	_, err := MakeOperator(core.InstanceDef{Operator: "eval"})
+	_, err := MakeOperator(core.InstanceDef{Operator: "slang.eval"})
 	a.Error(err)
 }
 
 func TestBuiltin_Eval__EmptyExpression(t *testing.T) {
 	a := assertions.New(t)
-	_, err := MakeOperator(core.InstanceDef{Operator: "eval", Properties: map[string]interface{}{"expression": ""}})
+	_, err := MakeOperator(core.InstanceDef{Operator: "slang.eval", Properties: map[string]interface{}{"expression": ""}})
 	a.Error(err)
 }
 
 func TestBuiltin_Eval__InvalidExpression(t *testing.T) {
 	a := assertions.New(t)
-	_, err := MakeOperator(core.InstanceDef{Operator: "eval", Properties: map[string]interface{}{"expression": "+"}})
+	_, err := MakeOperator(core.InstanceDef{Operator: "slang.eval", Properties: map[string]interface{}{"expression": "+"}})
 	a.Error(err)
 }
 
 func TestBuiltin_Eval__Add(t *testing.T) {
 	a := assertions.New(t)
 	fo, err := MakeOperator(core.InstanceDef{
-		Operator:   "eval",
+		Operator:   "slang.eval",
 		Properties: map[string]interface{}{"expression": "a+b"},
 		Generics: map[string]*core.PortDef{
 			"paramsMap": {
@@ -295,7 +295,7 @@ func TestBuiltin_Eval__Add(t *testing.T) {
 func TestBuiltin_Eval__Floor(t *testing.T) {
 	a := assertions.New(t)
 	fo, err := MakeOperator(core.InstanceDef{
-		Operator:   "eval",
+		Operator:   "slang.eval",
 		Properties: map[string]interface{}{"expression": "floor(a)"},
 		Generics: map[string]*core.PortDef{
 			"paramsMap": {
@@ -322,7 +322,7 @@ func TestBuiltin_Eval__Floor(t *testing.T) {
 func TestBuiltin_Eval__Ceil(t *testing.T) {
 	a := assertions.New(t)
 	fo, err := MakeOperator(core.InstanceDef{
-		Operator:   "eval",
+		Operator:   "slang.eval",
 		Properties: map[string]interface{}{"expression": "ceil(a)"},
 		Generics: map[string]*core.PortDef{
 			"paramsMap": {
@@ -349,7 +349,7 @@ func TestBuiltin_Eval__Ceil(t *testing.T) {
 func TestBuiltin_Eval__BoolArith(t *testing.T) {
 	a := assertions.New(t)
 	fo, err := MakeOperator(core.InstanceDef{
-		Operator:   "eval",
+		Operator:   "slang.eval",
 		Properties: map[string]interface{}{"expression": "a && (b != c)"},
 		Generics: map[string]*core.PortDef{
 			"paramsMap": {
@@ -380,7 +380,7 @@ func TestBuiltin_Eval__BoolArith(t *testing.T) {
 func TestBuiltin_Eval_VectorArith(t *testing.T) {
 	a := assertions.New(t)
 	fo, err := MakeOperator(core.InstanceDef{
-		Operator:   "eval",
+		Operator:   "slang.eval",
 		Properties: map[string]interface{}{"expression": "vec0.x*vec1.x+vec0.y*vec1.y"},
 		Generics: map[string]*core.PortDef{
 			"paramsMap": {

--- a/builtin/fork_test.go
+++ b/builtin/fork_test.go
@@ -10,7 +10,7 @@ import (
 func TestBuiltin_Fork__CreatorFuncIsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocFork := getBuiltinCfg("fork")
+	ocFork := getBuiltinCfg("slang.fork")
 	a.NotNil(ocFork)
 }
 
@@ -19,7 +19,7 @@ func TestBuiltin_Fork__InPorts(t *testing.T) {
 
 	o, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "fork",
+			Operator: "slang.fork",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
@@ -40,7 +40,7 @@ func TestBuiltin_Fork__OutPorts(t *testing.T) {
 
 	o, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "fork",
+			Operator: "slang.fork",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
@@ -61,7 +61,7 @@ func TestBuiltin_Fork__Correct(t *testing.T) {
 
 	o, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "fork",
+			Operator: "slang.fork",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
@@ -101,7 +101,7 @@ func TestBuiltin_Fork__ComplexItems(t *testing.T) {
 	a := assertions.New(t)
 	o, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "fork",
+			Operator: "slang.fork",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "map",

--- a/builtin/loop_test.go
+++ b/builtin/loop_test.go
@@ -10,7 +10,7 @@ import (
 func TestOperatorCreator_Loop_IsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocLoop := getBuiltinCfg("loop")
+	ocLoop := getBuiltinCfg("slang.loop")
 	a.NotNil(ocLoop)
 }
 
@@ -19,7 +19,7 @@ func TestBuiltin_Loop__Simple(t *testing.T) {
 	lo, err := MakeOperator(
 		core.InstanceDef{
 			Name: "loop",
-			Operator: "loop",
+			Operator: "slang.loop",
 			Generics: map[string]*core.PortDef{
 				"stateType": {
 					Type: "number",
@@ -88,7 +88,7 @@ func TestBuiltin_Loop__Fibo(t *testing.T) {
 	}
 	lo, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "loop",
+			Operator: "slang.loop",
 			Generics: map[string]*core.PortDef{
 				"stateType": &stateType,
 			},
@@ -156,7 +156,7 @@ func TestBuiltin_Loop__MarkersPushedCorrectly(t *testing.T) {
 	a := assertions.New(t)
 	lo, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "loop",
+			Operator: "slang.loop",
 			Generics: map[string]*core.PortDef{
 				"stateType": {
 					Type: "number",

--- a/builtin/manager.go
+++ b/builtin/manager.go
@@ -105,16 +105,16 @@ func Register(name string, cfg *builtinConfig) {
 
 func init() {
 	cfgs = make(map[string]*builtinConfig)
-	Register("const", constOpCfg)
-	Register("eval", evalOpCfg)
-	Register("fork", forkOpCfg)
-	Register("loop", loopOpCfg)
-	Register("merge", mergeOpCfg)
-	Register("take", takeOpCfg)
-	Register("agg", aggOpCfg)
-	Register("reduce", reduceOpCfg)
-	Register("syncFork", syncForkOpCfg)
-	Register("syncMerge", syncMergeOpCfg)
+	Register("slang.const", constOpCfg)
+	Register("slang.eval", evalOpCfg)
+	Register("slang.fork", forkOpCfg)
+	Register("slang.loop", loopOpCfg)
+	Register("slang.merge", mergeOpCfg)
+	Register("slang.take", takeOpCfg)
+	Register("slang.aggregate", aggregateOpCfg)
+	Register("slang.reduce", reduceOpCfg)
+	Register("slang.syncFork", syncForkOpCfg)
+	Register("slang.syncMerge", syncMergeOpCfg)
 }
 
 func getBuiltinCfg(name string) *builtinConfig {

--- a/builtin/merge_test.go
+++ b/builtin/merge_test.go
@@ -10,14 +10,14 @@ import (
 func TestBuiltin_Merge__CreatorFuncIsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocFork := getBuiltinCfg("merge")
+	ocFork := getBuiltinCfg("slang.merge")
 	a.NotNil(ocFork)
 }
 
 func TestBuiltin_Merge__InPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.In().Map("true").Stream())
@@ -28,7 +28,7 @@ func TestBuiltin_Merge__InPorts(t *testing.T) {
 func TestBuiltin_Merge__OutPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.Out().Stream())
@@ -37,7 +37,7 @@ func TestBuiltin_Merge__OutPorts(t *testing.T) {
 func TestBuiltin_Merge__Works(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.merge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	o.Out().Bufferize()
@@ -57,7 +57,7 @@ func TestBuiltin_Merge__Works(t *testing.T) {
 func TestBuiltin_Merge__ComplexItems(t *testing.T) {
 	a := assertions.New(t)
 	o, err := MakeOperator(core.InstanceDef{
-		Operator: "merge",
+		Operator: "slang.merge",
 		Generics: map[string]*core.PortDef{"itemType": {Type: "map", Map: map[string]*core.PortDef{"red": {Type: "string"}, "blue": {Type: "string"}}}},
 	})
 	require.NoError(t, err)

--- a/builtin/reduce_test.go
+++ b/builtin/reduce_test.go
@@ -10,14 +10,14 @@ import (
 func TestBuiltin_Reduce__CreatorFuncIsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocReduce := getBuiltinCfg("reduce")
+	ocReduce := getBuiltinCfg("slang.reduce")
 	a.NotNil(ocReduce)
 }
 
 func TestBuiltin_Reduce__NoGenerics(t *testing.T) {
 	a := assertions.New(t)
 
-	_, err := MakeOperator(core.InstanceDef{Operator: "reduce"})
+	_, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce"})
 	a.Error(err)
 }
 
@@ -25,7 +25,7 @@ func TestBuiltin_Reduce__InPorts(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	a.Equal(core.TYPE_STREAM, o.In().Type())
@@ -36,7 +36,7 @@ func TestBuiltin_Reduce__InPorts(t *testing.T) {
 	a.Equal(itemType, o.In().Stream().Type())
 	a.Equal(itemType, o.Delegate("selection").In().Stream().Type())
 
-	o, err = MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "string"}}})
+	o, err = MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "string"}}})
 	r.NoError(err)
 
 	// Item type
@@ -50,7 +50,7 @@ func TestBuiltin_Reduce__OutPorts(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	a.Equal(core.TYPE_NUMBER, o.Out().Type())
@@ -62,7 +62,7 @@ func TestBuiltin_Reduce__OutPorts(t *testing.T) {
 	a.Equal(itemType, o.Delegate("selection").Out().Stream().Map("a").Type())
 	a.Equal(itemType, o.Delegate("selection").Out().Stream().Map("b").Type())
 
-	o, err = MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "string"}}})
+	o, err = MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "string"}}})
 	r.NoError(err)
 
 	// Item type
@@ -75,7 +75,7 @@ func TestBuiltin_Reduce__PassMarkers(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	o.Out().Bufferize()
@@ -97,7 +97,7 @@ func TestBuiltin_Reduce__SelectionFromItemsEmpty(t *testing.T) {
 	r := require.New(t)
 
 	o, err := MakeOperator(core.InstanceDef{
-		Operator: "reduce",
+		Operator: "slang.reduce",
 		Generics: map[string]*core.PortDef{"itemType": {Type: "string"}},
 		Properties: map[string]interface{}{"emptyValue": "empty"},
 	})
@@ -118,7 +118,7 @@ func TestBuiltin_Reduce__SelectionFromItemsSingle(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	o.Out().Bufferize()
@@ -136,7 +136,7 @@ func TestBuiltin_Reduce__SelectionFromItemsMultiple(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	o.Out().Bufferize()
@@ -158,7 +158,7 @@ func TestBuiltin_Reduce__SelectionFromPool(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	o.Out().Bufferize()
@@ -183,7 +183,7 @@ func TestBuiltin_Reduce__MixedSelection1(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	o.Out().Bufferize()
@@ -204,7 +204,7 @@ func TestBuiltin_Reduce__MixedSelection2(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	o.Out().Bufferize()
@@ -245,7 +245,7 @@ func TestBuiltin_Reduce__MixedSelection3(t *testing.T) {
 	a := assertions.New(t)
 	r := require.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.reduce", Generics: map[string]*core.PortDef{"itemType": {Type: "number"}}})
 	r.NoError(err)
 
 	o.Out().Bufferize()

--- a/builtin/sync_fork_test.go
+++ b/builtin/sync_fork_test.go
@@ -10,7 +10,7 @@ import (
 func TestBuiltin_SyncFork__CreatorFuncIsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocFork := getBuiltinCfg("syncFork")
+	ocFork := getBuiltinCfg("slang.syncFork")
 	a.NotNil(ocFork)
 }
 
@@ -19,7 +19,7 @@ func TestBuiltin_SyncFork__InPorts(t *testing.T) {
 
 	o, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "syncFork",
+			Operator: "slang.syncFork",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
@@ -40,7 +40,7 @@ func TestBuiltin_SyncFork__OutPorts(t *testing.T) {
 
 	o, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "syncFork",
+			Operator: "slang.syncFork",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
@@ -61,7 +61,7 @@ func TestBuiltin_SyncFork__Correct(t *testing.T) {
 
 	o, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "syncFork",
+			Operator: "slang.syncFork",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "primitive",
@@ -103,7 +103,7 @@ func TestBuiltin_SyncFork__ComplexItems(t *testing.T) {
 	a := assertions.New(t)
 	o, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "syncFork",
+			Operator: "slang.syncFork",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "map",

--- a/builtin/sync_merge_test.go
+++ b/builtin/sync_merge_test.go
@@ -10,14 +10,14 @@ import (
 func TestBuiltin_SyncMerge__CreatorFuncIsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocFork := getBuiltinCfg("syncMerge")
+	ocFork := getBuiltinCfg("slang.syncMerge")
 	a.NotNil(ocFork)
 }
 
 func TestBuiltin_SyncMerge__InPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.In().Map("true"))
@@ -31,7 +31,7 @@ func TestBuiltin_SyncMerge__InPorts(t *testing.T) {
 func TestBuiltin_SyncMerge__OutPorts(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	a.NotNil(o.Out())
@@ -41,7 +41,7 @@ func TestBuiltin_SyncMerge__OutPorts(t *testing.T) {
 func TestBuiltin_SyncMerge__Works(t *testing.T) {
 	a := assertions.New(t)
 
-	o, err := MakeOperator(core.InstanceDef{Operator: "syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
+	o, err := MakeOperator(core.InstanceDef{Operator: "slang.syncMerge", Generics: map[string]*core.PortDef{"itemType": {Type: "primitive"}}})
 	require.NoError(t, err)
 
 	o.Out().Bufferize()
@@ -67,7 +67,7 @@ func TestBuiltin_SyncMerge__Works(t *testing.T) {
 func TestBuiltin_SyncMerge__ComplexItems(t *testing.T) {
 	a := assertions.New(t)
 	o, err := MakeOperator(core.InstanceDef{
-		Operator: "syncMerge",
+		Operator: "slang.syncMerge",
 		Generics: map[string]*core.PortDef{"itemType": {Type: "map", Map: map[string]*core.PortDef{"red": {Type: "string"}, "blue": {Type: "string"}}}},
 	})
 	require.NoError(t, err)

--- a/builtin/take_test.go
+++ b/builtin/take_test.go
@@ -10,7 +10,7 @@ import (
 func TestOperator_Take__IsRegistered(t *testing.T) {
 	a := assertions.New(t)
 
-	ocTake := getBuiltinCfg("take")
+	ocTake := getBuiltinCfg("slang.take")
 	a.NotNil(ocTake)
 }
 
@@ -18,7 +18,7 @@ func TestOperator_Take__NoGenerics(t *testing.T) {
 	a := assertions.New(t)
 	co, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "take",
+			Operator: "slang.take",
 		},
 	)
 	a.Error(err)
@@ -29,7 +29,7 @@ func TestOperator_Take__InPorts(t *testing.T) {
 	a := assertions.New(t)
 	to, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "take",
+			Operator: "slang.take",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "number",
@@ -53,7 +53,7 @@ func TestOperator_Take__OutPorts(t *testing.T) {
 	a := assertions.New(t)
 	to, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "take",
+			Operator: "slang.take",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "number",
@@ -76,7 +76,7 @@ func TestOperator_Take__Simple1(t *testing.T) {
 	a := assertions.New(t)
 	to, err := MakeOperator(
 		core.InstanceDef{
-			Operator: "take",
+			Operator: "slang.take",
 			Generics: map[string]*core.PortDef{
 				"itemType": {
 					Type: "number",

--- a/tests/test_data/delegates/del2_op.yaml
+++ b/tests/test_data/delegates/del2_op.yaml
@@ -27,7 +27,7 @@ operators:
         type: generic
         generic: gen
   const:
-    operator: const
+    operator: slang.const
     generics:
       valueType:
         type: generic

--- a/tests/test_data/delegates/wrapper_op.yaml
+++ b/tests/test_data/delegates/wrapper_op.yaml
@@ -15,7 +15,7 @@ operators:
     properties:
       val: $val
   cmp:
-    operator: eval
+    operator: slang.eval
     generics:
       paramsMap:
         type: map

--- a/tests/test_data/nested_op/customOp.json
+++ b/tests/test_data/nested_op/customOp.json
@@ -8,7 +8,7 @@
   },
   "operators": {
     "passer": {
-      "operator": "eval",
+      "operator": "slang.eval",
       "properties": {
         "expression": "a"
       },

--- a/tests/test_data/nested_op/sub/customOpDouble.json
+++ b/tests/test_data/nested_op/sub/customOpDouble.json
@@ -7,7 +7,7 @@
   },
   "operators": {
     "doubler": {
-      "operator": "eval",
+      "operator": "slang.eval",
       "properties": {
         "expression": "a+a"
       },

--- a/tests/test_data/properties/prop_op.yaml
+++ b/tests/test_data/properties/prop_op.yaml
@@ -7,7 +7,7 @@ properties:
 
 operators:
   const:
-    operator: const
+    operator: slang.const
     generics:
       valueType:
         type: number

--- a/tests/test_data/slib/merge_sort.yaml
+++ b/tests/test_data/slib/merge_sort.yaml
@@ -18,13 +18,13 @@ operators:
         type: number
   # Sorter
   sorter:
-    operator: take
+    operator: slang.take
     generics:
       itemType:
         type: number
   # Reducer
   reducer:
-    operator: reduce
+    operator: slang.reduce
     generics:
       itemType:
         type: stream
@@ -34,7 +34,7 @@ operators:
       emptyValue: []
   # Comparator
   comparator:
-    operator: eval
+    operator: slang.eval
     generics:
       paramsMap:
         type: map

--- a/tests/test_data/slib/pack.yaml
+++ b/tests/test_data/slib/pack.yaml
@@ -10,14 +10,14 @@ out:
 
 operators:
   loop:
-    operator: loop
+    operator: slang.loop
     generics:
       itemType:
         type: number
       stateType:
         type: number
   falsify:
-    operator: const
+    operator: slang.const
     generics:
       valueType:
         type: boolean

--- a/tests/test_data/suite/polynomial.yaml
+++ b/tests/test_data/suite/polynomial.yaml
@@ -15,7 +15,7 @@ out:
   type: number
 operators:
   pfunc:
-    operator: eval
+    operator: slang.eval
     properties:
       expression: "a*x*x + b*x + c"
     generics:

--- a/tests/test_data/sum/reduce.yaml
+++ b/tests/test_data/sum/reduce.yaml
@@ -8,7 +8,7 @@ out:
   type: number
 operators:
   adder:
-    operator: "eval"
+    operator: slang.eval
     generics:
       paramsMap:
         type: map
@@ -20,7 +20,7 @@ operators:
     properties:
       expression: "a+b"
   reducer:
-    operator: "reduce"
+    operator: slang.reduce
     generics:
       itemType:
         type: number

--- a/tests/test_data/usingBuiltinOp.json
+++ b/tests/test_data/usingBuiltinOp.json
@@ -8,7 +8,7 @@
   },
   "operators": {
     "passer": {
-      "operator": "eval",
+      "operator": "slang.eval",
       "properties": {
         "expression": "a"
       },


### PR DESCRIPTION
Registering builtins under library-like names allows us to move implementation to the standard library later and vice versa without breaking the naming concept