### PR TITLE
Add TYPE_BINARY

### DIFF
--- a/builtin/file_read.go
+++ b/builtin/file_read.go
@@ -14,7 +14,7 @@ var fileReadOpCfg = &builtinConfig{
 			Type: "map",
 			Map: map[string]*core.PortDef{
 				"content": {
-					Type: "string",
+					Type: "binary",
 				},
 				"error": {
 					Type: "string",
@@ -37,7 +37,7 @@ var fileReadOpCfg = &builtinConfig{
 				continue
 			}
 
-			out.Map("content").Push(string(content))
+			out.Map("content").Push(content)
 			out.Map("error").Push(nil)
 		}
 	},

--- a/builtin/file_read_test.go
+++ b/builtin/file_read_test.go
@@ -40,7 +40,7 @@ func TestBuiltin_FileRead__OutPorts(t *testing.T) {
 
 	a.NotNil(o.Out())
 	a.Equal(core.TYPE_MAP, o.Out().Type())
-	a.Equal(core.TYPE_STRING, o.Out().Map("content").Type())
+	a.Equal(core.TYPE_BINARY, o.Out().Map("content").Type())
 	a.Equal(core.TYPE_STRING, o.Out().Map("error").Type())
 }
 
@@ -58,7 +58,7 @@ func TestBuiltin_FileRead__Simple(t *testing.T) {
 	o.Start()
 
 	o.In().Push("../tests/test_data/hello.txt")
-	a.Equal("hello slang", o.Out().Map("content").Pull())
+	a.Equal([]byte("hello slang"), o.Out().Map("content").Pull())
 	a.Nil(o.Out().Map("error").Pull())
 }
 

--- a/builtin/http_server.go
+++ b/builtin/http_server.go
@@ -32,7 +32,7 @@ func (r *requestHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(req.Body)
-	hOut.Map("body").Push(buf.String())
+	hOut.Map("body").Push(buf.Bytes())
 
 	// Gather all response information
 	statusCode, _ := hIn.Map("status").PullInt()
@@ -44,7 +44,7 @@ func (r *requestHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	resp.WriteHeader(statusCode)
-	body, _ := hIn.Map("body").PullString()
+	body, _ := hIn.Map("body").PullBinary()
 	resp.Write([]byte(body))
 }
 
@@ -81,7 +81,7 @@ var httpServerOpCfg = &builtinConfig{
 								},
 							},
 							"body": {
-								Type: "string",
+								Type: "binary",
 							},
 						},
 					},
@@ -115,7 +115,7 @@ var httpServerOpCfg = &builtinConfig{
 								},
 							},
 							"body": {
-								Type: "string",
+								Type: "binary",
 							},
 						},
 					},

--- a/builtin/http_server_test.go
+++ b/builtin/http_server_test.go
@@ -64,7 +64,7 @@ func TestBuiltin_HTTP__Delegates(t *testing.T) {
 	a.Equal(core.TYPE_MAP, dlg.In().Stream().Type())
 	a.Equal(core.TYPE_MAP, dlg.Out().Stream().Type())
 
-	a.Equal(core.TYPE_STRING, dlg.In().Stream().Map("body").Type())
+	a.Equal(core.TYPE_BINARY, dlg.In().Stream().Map("body").Type())
 	a.Equal(core.TYPE_NUMBER, dlg.In().Stream().Map("status").Type())
 	a.Equal(core.TYPE_STREAM, dlg.In().Stream().Map("headers").Type())
 	a.Equal(core.TYPE_MAP, dlg.In().Stream().Map("headers").Stream().Type())
@@ -125,14 +125,14 @@ func TestBuiltin_HTTP__Response200(t *testing.T) {
 	o.In().Push(9439)
 	a.True(handler.Out().PullBOS())
 	handler.In().PushBOS()
-	handler.In().Stream().Push(map[string]interface{}{"status": 200, "headers": []interface{}{}, "body": "hallo slang!"})
+	handler.In().Stream().Push(map[string]interface{}{"status": 200, "headers": []interface{}{}, "body": []byte("hallo slang!")})
 
 	time.Sleep(500 * time.Millisecond)
 	resp, _ := http.Get("http://127.0.0.1:9439/test789")
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Body)
 
-	a.Equal("hallo slang!", buf.String())
+	a.Equal([]byte("hallo slang!"), buf.Bytes())
 	a.Equal("200 OK", resp.Status)
 }
 
@@ -154,13 +154,13 @@ func TestBuiltin_HTTP__Response404(t *testing.T) {
 	o.In().Push(9440)
 	a.True(handler.Out().PullBOS())
 	handler.In().PushBOS()
-	handler.In().Stream().Push(map[string]interface{}{"status": 404, "headers": []interface{}{}, "body": "bye slang!"})
+	handler.In().Stream().Push(map[string]interface{}{"status": 404, "headers": []interface{}{}, "body": []byte("bye slang!")})
 
 	time.Sleep(500 * time.Millisecond)
 	resp, _ := http.Get("http://127.0.0.1:9440/test789")
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Body)
 
-	a.Equal("bye slang!", buf.String())
+	a.Equal([]byte("bye slang!"), buf.Bytes())
 	a.Equal("404 Not Found", resp.Status)
 }

--- a/core/def.go
+++ b/core/def.go
@@ -246,7 +246,7 @@ func (d *PortDef) Validate() error {
 		return errors.New("type must not be empty")
 	}
 
-	validTypes := []string{"generic", "primitive", "trigger", "number", "string", "boolean", "stream", "map"}
+	validTypes := []string{"generic", "primitive", "trigger", "number", "string", "binary", "boolean", "stream", "map"}
 	found := false
 	for _, t := range validTypes {
 		if t == d.Type {

--- a/core/port.go
+++ b/core/port.go
@@ -12,6 +12,7 @@ const (
 	TYPE_TRIGGER   = iota
 	TYPE_NUMBER    = iota
 	TYPE_STRING    = iota
+	TYPE_BINARY    = iota
 	TYPE_BOOLEAN   = iota
 	TYPE_STREAM    = iota
 	TYPE_MAP       = iota
@@ -98,6 +99,8 @@ func NewPort(o *Operator, d *Delegate, def PortDef, dir int) (*Port, error) {
 		p.itemType = TYPE_NUMBER
 	case "string":
 		p.itemType = TYPE_STRING
+	case "binary":
+		p.itemType = TYPE_BINARY
 	case "boolean":
 		p.itemType = TYPE_BOOLEAN
 	}
@@ -418,6 +421,15 @@ func (p *Port) PullString() (string, interface{}) {
 	return "", item
 }
 
+// Pull a binary object and panic if not possible
+func (p *Port) PullBinary() ([]byte, interface{}) {
+	item := p.Pull()
+	if b, ok := item.([]byte); ok {
+		return b, nil
+	}
+	return nil, item
+}
+
 func (p *Port) PullBOS() bool {
 	if !p.OwnBOS(p.sub.Pull()) {
 		panic("expected own BOS")
@@ -503,6 +515,8 @@ func (p *Port) Name() string {
 		name += "_NUMBER"
 	case TYPE_STRING:
 		name += "_STRING"
+	case TYPE_BINARY:
+		name += "_BINARY"
 	case TYPE_BOOLEAN:
 		name += "_BOOLEAN"
 	case TYPE_MAP:
@@ -647,5 +661,6 @@ func (p *Port) primitive() bool {
 		p.itemType == TYPE_TRIGGER ||
 		p.itemType == TYPE_NUMBER ||
 		p.itemType == TYPE_STRING ||
+		p.itemType == TYPE_BINARY ||
 		p.itemType == TYPE_BOOLEAN
 }


### PR DESCRIPTION
Reasons to add:
We need a way to transmit binary data for file contents, multimedia content, compressed content etc.

Content:
* Add `TYPE_BINARY`
* Use new binary type in `builtin.ReadFile` and `builtin.HttpServer`