### PR TITLE
Implement core.Synchronizer

### DIFF
--- a/builtin/http_server.go
+++ b/builtin/http_server.go
@@ -10,42 +10,44 @@ import (
 
 type requestHandler struct {
 	hOut *core.Port
-	hIn *core.Port
+	hIn  *core.Port
+	sync *core.Synchronizer
 }
 
 func (r *requestHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	hIn := r.hIn
-	hOut := r.hOut
+	token := r.sync.Push(func(out *core.Port) {
+		// Push out all request information
+		out.Map("method").Push(req.Method)
+		out.Map("path").Push(req.URL.String())
+		out.Map("protocol").Push(req.Proto)
 
-	// Push out all request information
-	hOut.Map("method").Push(req.Method)
-	hOut.Map("path").Push(req.URL.String())
-	hOut.Map("protocol").Push(req.Proto)
+		out.Map("headers").PushBOS()
+		headersOut := out.Map("headers").Stream()
+		for key, val := range req.Header {
+			headersOut.Map("key").Push(key)
+			headersOut.Map("value").Push(val)
+		}
+		out.Map("headers").PushEOS()
 
-	hOut.Map("headers").PushBOS()
-	headersOut := hOut.Map("headers").Stream()
-	for key, val := range req.Header {
-		headersOut.Map("key").Push(key)
-		headersOut.Map("value").Push(val)
-	}
-	hOut.Map("headers").PushEOS()
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(req.Body)
+		out.Map("body").Push(buf.Bytes())
+	})
 
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(req.Body)
-	hOut.Map("body").Push(buf.Bytes())
+	r.sync.Pull(token, func(in *core.Port) {
+		// Gather all response information
+		statusCode, _ := in.Map("status").PullInt()
 
-	// Gather all response information
-	statusCode, _ := hIn.Map("status").PullInt()
+		headers := in.Map("headers").Pull().([]interface{})
+		for _, entry := range headers {
+			header := entry.(map[string]interface{})
+			resp.Header().Set(header["key"].(string), header["value"].(string))
+		}
 
-	headers := hIn.Map("headers").Pull().([]interface{})
-	for _, entry := range headers {
-		header := entry.(map[string]interface{})
-		resp.Header().Set(header["key"].(string), header["value"].(string))
-	}
-
-	resp.WriteHeader(statusCode)
-	body, _ := hIn.Map("body").PullBinary()
-	resp.Write([]byte(body))
+		resp.WriteHeader(statusCode)
+		body, _ := in.Map("body").PullBinary()
+		resp.Write([]byte(body))
+	})
 }
 
 var httpServerOpCfg = &builtinConfig{
@@ -125,8 +127,11 @@ var httpServerOpCfg = &builtinConfig{
 	},
 	oFunc: func(in, out *core.Port, dels map[string]*core.Delegate, store interface{}) {
 		slangHandler := dels["handler"]
-		hOut := slangHandler.Out().Stream()
-		hIn := slangHandler.In().Stream()
+		sync := &core.Synchronizer{}
+		sync.Init(
+			slangHandler.In().Stream(),
+			slangHandler.Out().Stream())
+		go sync.Worker()
 
 		for true {
 			port, marker := in.PullInt()
@@ -141,7 +146,7 @@ var httpServerOpCfg = &builtinConfig{
 
 			s := &http.Server{
 				Addr:           ":" + strconv.Itoa(port),
-				Handler:        &requestHandler{hIn: hIn, hOut: hOut},
+				Handler:        &requestHandler{sync: sync},
 				ReadTimeout:    10 * time.Second,
 				WriteTimeout:   10 * time.Second,
 				MaxHeaderBytes: 1 << 20,

--- a/builtin/http_server_test.go
+++ b/builtin/http_server_test.go
@@ -127,13 +127,19 @@ func TestBuiltin_HTTP__Response200(t *testing.T) {
 	handler.In().PushBOS()
 	handler.In().Stream().Push(map[string]interface{}{"status": 200, "headers": []interface{}{}, "body": []byte("hallo slang!")})
 
-	time.Sleep(500 * time.Millisecond)
-	resp, _ := http.Get("http://127.0.0.1:9439/test789")
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
-
-	a.Equal([]byte("hallo slang!"), buf.Bytes())
-	a.Equal("200 OK", resp.Status)
+	for i := 0; i < 10; i++ {
+		resp, _ := http.Get("http://127.0.0.1:9439/test789")
+		if resp.StatusCode != 200 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		a.Equal([]byte("hallo slang!"), buf.Bytes())
+		a.Equal("200 OK", resp.Status)
+		return
+	}
+	a.Fail("no response")
 }
 
 func TestBuiltin_HTTP__Response404(t *testing.T) {
@@ -156,11 +162,17 @@ func TestBuiltin_HTTP__Response404(t *testing.T) {
 	handler.In().PushBOS()
 	handler.In().Stream().Push(map[string]interface{}{"status": 404, "headers": []interface{}{}, "body": []byte("bye slang!")})
 
-	time.Sleep(500 * time.Millisecond)
-	resp, _ := http.Get("http://127.0.0.1:9440/test789")
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
-
-	a.Equal([]byte("bye slang!"), buf.Bytes())
-	a.Equal("404 Not Found", resp.Status)
+	for i := 0; i < 10; i++ {
+		resp, _ := http.Get("http://127.0.0.1:9440/test789")
+		if resp.StatusCode != 404 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		a.Equal([]byte("bye slang!"), buf.Bytes())
+		a.Equal("404 Not Found", resp.Status)
+		return
+	}
+	a.Fail("no response")
 }

--- a/builtin/http_server_test.go
+++ b/builtin/http_server_test.go
@@ -99,12 +99,21 @@ func TestBuiltin_HTTP__Request(t *testing.T) {
 	a.True(handler.Out().PullBOS())
 	handler.In().PushBOS()
 
+	done := false
+
 	go func() {
-		http.Get("http://127.0.0.1:9438/test123")
+		for i := 0; i < 5; i++ {
+			http.Get("http://127.0.0.1:9438/test123")
+			if done {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
 	}()
 
 	a.Equal("GET", handler.Out().Stream().Map("method").Pull())
 	a.Equal("/test123", handler.Out().Stream().Map("path").Pull())
+	done = true
 }
 
 func TestBuiltin_HTTP__Response200(t *testing.T) {
@@ -127,10 +136,10 @@ func TestBuiltin_HTTP__Response200(t *testing.T) {
 	handler.In().PushBOS()
 	handler.In().Stream().Push(map[string]interface{}{"status": 200, "headers": []interface{}{}, "body": []byte("hallo slang!")})
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		resp, _ := http.Get("http://127.0.0.1:9439/test789")
 		if resp.StatusCode != 200 {
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 			continue
 		}
 		buf := new(bytes.Buffer)
@@ -162,10 +171,10 @@ func TestBuiltin_HTTP__Response404(t *testing.T) {
 	handler.In().PushBOS()
 	handler.In().Stream().Push(map[string]interface{}{"status": 404, "headers": []interface{}{}, "body": []byte("bye slang!")})
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		resp, _ := http.Get("http://127.0.0.1:9440/test789")
 		if resp.StatusCode != 404 {
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 			continue
 		}
 		buf := new(bytes.Buffer)

--- a/core/synchronizer.go
+++ b/core/synchronizer.go
@@ -1,17 +1,17 @@
 package core
 
 import (
-	"math/rand"
 	"sync"
 )
 
 type Synchronizer struct {
-	out   *Port
-	in    *Port
-	queue chan int64
-	tasks map[int64]chan pullFunc
-	done  map[int64]chan bool
-	mutex *sync.Mutex
+	out     *Port
+	in      *Port
+	queue   chan int64
+	tasks   map[int64]chan pullFunc
+	done    map[int64]chan bool
+	mutex   *sync.Mutex
+	counter int64
 }
 
 type pushFunc func(port *Port)
@@ -27,10 +27,9 @@ func (s *Synchronizer) Init(in, out *Port) {
 }
 
 func (s *Synchronizer) Push(push pushFunc) int64 {
-	var token int64
-	token = rand.Int63()
-
 	s.mutex.Lock()
+	s.counter++
+	token := s.counter
 	push(s.out)
 	s.tasks[token] = make(chan pullFunc)
 	s.done[token] = make(chan bool)

--- a/core/synchronizer.go
+++ b/core/synchronizer.go
@@ -44,6 +44,7 @@ func (s *Synchronizer) Pull(token int64, pull pullFunc) {
 	s.tasks[token] <- pull
 	<-s.done[token]
 	delete(s.tasks, token)
+	delete(s.done, token)
 }
 
 func (s *Synchronizer) Worker() {

--- a/core/synchronizer.go
+++ b/core/synchronizer.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"math/rand"
+	"sync"
+)
+
+type Synchronizer struct {
+	out   *Port
+	in    *Port
+	queue chan int64
+	tasks map[int64]chan pullFunc
+	done  map[int64]chan bool
+	mutex *sync.Mutex
+}
+
+type pushFunc func(port *Port)
+type pullFunc func(port *Port)
+
+func (s *Synchronizer) Init(in, out *Port) {
+	s.in = in
+	s.out = out
+	s.queue = make(chan int64)
+	s.tasks = make(map[int64]chan pullFunc)
+	s.done = make(map[int64]chan bool)
+	s.mutex = &sync.Mutex{}
+}
+
+func (s *Synchronizer) Push(push pushFunc) int64 {
+	var token int64
+	token = rand.Int63()
+
+	s.mutex.Lock()
+	push(s.out)
+	s.tasks[token] = make(chan pullFunc)
+	s.done[token] = make(chan bool)
+	s.queue <- token // order is important! worker expects to have s.tasks[token] once it can pull the token from queue
+	s.mutex.Unlock()
+
+	return token
+}
+
+func (s *Synchronizer) Pull(token int64, pull pullFunc) {
+	s.tasks[token] <- pull
+	<-s.done[token]
+	delete(s.tasks, token)
+}
+
+func (s *Synchronizer) Worker() {
+	for true {
+		token := <-s.queue
+		pull := <-s.tasks[token]
+		pull(s.in)
+		s.done[token] <- true
+	}
+}


### PR DESCRIPTION
In this PR, a `core.Synchronizer` is implemented which ensures handling pushing and pulling in the correct order. It is also integrated into the `builtin.HttpServer` where we need such handling.

Secondly, HTTP tests are made more rubust in this PR.