### PR TITLE
Use ~ as stream symbol in port references

### DIFF
--- a/slang.go
+++ b/slang.go
@@ -146,13 +146,12 @@ func ParsePortReference(refStr string, par *core.Operator) (*core.Port, error) {
 		}
 	}
 
-	start := 0
-	if pathSplit[0] == "" {
-		start = 1
+	if len(pathSplit) == 1 && pathSplit[0] == "" {
+		return p, nil
 	}
 
-	for i := start; i < len(pathSplit); i++ {
-		if pathSplit[i] == "" {
+	for i := 0; i < len(pathSplit); i++ {
+		if pathSplit[i] == "~" {
 			p = p.Stream()
 			if p == nil {
 				return nil, errors.New("descending too deep (stream)")

--- a/tests/slang_test.go
+++ b/tests/slang_test.go
@@ -215,7 +215,7 @@ func TestParsePortReference__Stream(t *testing.T) {
 	o1, _ := core.NewOperator("o1", nil, core.PortDef{Type: "number"}, core.PortDef{Type: "number"}, nil)
 	o2, _ := core.NewOperator("o2", nil, core.PortDef{Type: "stream", Stream: &core.PortDef{Type: "number"}}, core.PortDef{Type: "number"}, nil)
 	o2.SetParent(o1)
-	p, err := slang.ParsePortReference(".(o2", o1)
+	p, err := slang.ParsePortReference("~(o2", o1)
 	a.NoError(err)
 	a.Equal(o2.In().Stream(), p, "wrong port")
 }
@@ -249,7 +249,7 @@ func TestParsePortReference__StreamMap(t *testing.T) {
 		core.PortDef{Type: "number"},
 		nil)
 	o2.SetParent(o1)
-	p, err := slang.ParsePortReference("..a..a.(o2", o1)
+	p, err := slang.ParsePortReference("~.a.~.a.~(o2", o1)
 	a.NoError(err)
 	a.Equal(o2.In().Stream().Map("a").Stream().Map("a").Stream(), p, "wrong port")
 }

--- a/tests/test_data/slib/merge_sort.yaml
+++ b/tests/test_data/slib/merge_sort.yaml
@@ -47,21 +47,21 @@ operators:
       expression: a <= b
 
 connections:
-  .(:
+  ~(:
     - (packer
   packer):
-    - .(reducer
-  reducer.selection)..a:
+    - ~(reducer
+  reducer.selection)~.a:
     - true(sorter
-  reducer.selection)..b:
+  reducer.selection)~.b:
     - false(sorter
-  sorter.compare)..true:
+  sorter.compare)~.true:
     - a(comparator
-  sorter.compare)..false:
+  sorter.compare)~.false:
     - b(comparator
   comparator):
-    - .(sorter.compare
+    - ~(sorter.compare
   sorter):
-    - .(reducer.selection
+    - ~(reducer.selection
   reducer):
     - )

--- a/tests/test_data/slib/pack.yaml
+++ b/tests/test_data/slib/pack.yaml
@@ -28,13 +28,13 @@ connections:
   (:
   - (loop
 
-  loop.iteration).:
+  loop.iteration)~:
   - (falsify
-  - ..state(loop.iteration
+  - ~.state(loop.iteration
 
   loop.iteration):
   - )
 
   falsify):
-  - ..continue(loop.iteration
+  - ~.continue(loop.iteration
 

--- a/tests/test_data/sum/reduce.yaml
+++ b/tests/test_data/sum/reduce.yaml
@@ -31,7 +31,7 @@ connections:
     - (reducer
   reducer):
     - )
-  reducer.selection).:
+  reducer.selection)~:
     - (adder
   adder):
-    - .(reducer.selection
+    - ~(reducer.selection


### PR DESCRIPTION
I came to the conclusion that it would be better to have a specific symbol for streams in port references. @tidify suggested this a while ago and I think he was right 👍 