### PR TITLE
HTTP Clean up 

### DIFF
--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/Bitspark/slang/pkg/storage"
 	"log"
 	"net/http"
 	"os/user"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Bitspark/slang/pkg/storage"
 
 	"strconv"
 
@@ -76,7 +77,7 @@ func main() {
 	st := storage.
 		NewStorage(storage.NewFileSystem(envPaths.SLANG_DIR)).
 		AddLoader(storage.NewFileSystem(dirSlib))
-	srv := daemon.New(*st, "localhost", PORT)
+	srv := daemon.New("localhost", PORT)
 	ctx := context.WithValue(context.Background(), "storage", *st)
 	envPaths.loadDaemonServices(srv)
 	envPaths.startDaemonServer(srv, ctx)

--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -78,7 +78,8 @@ func main() {
 		NewStorage(storage.NewFileSystem(envPaths.SLANG_DIR)).
 		AddLoader(storage.NewFileSystem(dirSlib))
 	srv := daemon.New("localhost", PORT)
-	ctx := context.WithValue(context.Background(), "storage", *st)
+	ctx := context.WithValue(context.Background(), daemon.StorageKey, *st)
+
 	envPaths.loadDaemonServices(srv)
 	envPaths.startDaemonServer(srv, ctx)
 }

--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -154,8 +154,7 @@ func (e *EnvironPaths) loadLocalComponents() {
 
 func (e *EnvironPaths) loadDaemonServices(srv *daemon.Server) {
 	srv.AddRedirect("/", "/app/")
-	srv.AddAppServer("/app", http.Dir(e.SLANG_UI))
-	srv.AddAppServer("/studio", http.Dir(filepath.Join(filepath.Dir(e.SLANG_UI), "studio")))
+	srv.AddStaticServer("/app", http.Dir(e.SLANG_UI))
 	srv.AddService("/operator", daemon.DefinitionService)
 	srv.AddService("/run", daemon.RunnerService)
 	srv.AddService("/share", daemon.SharingService)

--- a/pkg/daemon/definition_service.go
+++ b/pkg/daemon/definition_service.go
@@ -2,16 +2,17 @@ package daemon
 
 import (
 	"encoding/json"
-	"github.com/Bitspark/slang/pkg/core"
-	"github.com/Bitspark/slang/pkg/elem"
-	"github.com/Bitspark/slang/pkg/storage"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/Bitspark/slang/pkg/core"
+	"github.com/Bitspark/slang/pkg/elem"
 )
 
 var DefinitionService = &Service{map[string]*Endpoint{
-	"/": {func(st storage.Storage, w http.ResponseWriter, r *http.Request) {
+	"/": {func(w http.ResponseWriter, r *http.Request) {
+		st := getStorage(r)
 		type operatorDefJSON struct {
 			Def  core.OperatorDef `json:"def"`
 			Type string           `json:"type"`
@@ -79,7 +80,8 @@ var DefinitionService = &Service{map[string]*Endpoint{
 			log.Print(err)
 		}
 	}},
-	"/def/": {func(e storage.Storage, w http.ResponseWriter, r *http.Request) {
+	"/def/": {func(w http.ResponseWriter, r *http.Request) {
+		st := getStorage(r)
 		fail := func(err *Error) {
 			sendFailure(w, &responseBad{err})
 		}
@@ -98,7 +100,7 @@ var DefinitionService = &Service{map[string]*Endpoint{
 				return
 			}
 
-			_, err = e.Store(def)
+			_, err = st.Store(def)
 
 			if err != nil {
 				fail(&Error{Msg: err.Error(), Code: "E000X"})

--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Bitspark/slang/pkg/api"
 	"github.com/Bitspark/slang/pkg/core"
-	"github.com/Bitspark/slang/pkg/storage"
 	"github.com/google/uuid"
 )
 
@@ -43,7 +42,8 @@ func (l *httpDefLoader) Load(opId uuid.UUID) (*core.OperatorDef, error) {
 }
 
 var RunnerService = &Service{map[string]*Endpoint{
-	"/": {func(st storage.Storage, w http.ResponseWriter, r *http.Request) {
+	"/": {func(w http.ResponseWriter, r *http.Request) {
+		st := getStorage(r)
 		if r.Method == "POST" {
 			type runInstructionJSON struct {
 				Id     string          `json:"id"`

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -13,24 +13,22 @@ import (
 var SlangVersion string
 
 type Server struct {
-	Storage storage.Storage
-	Host    string
-	Port    int
-	router  *mux.Router
+	Host   string
+	Port   int
+	router *mux.Router
 }
 
-func New(s storage.Storage, host string, port int) *Server {
-	r := mux.NewRouter()
+func New(host string, port int) *Server {
+	r := mux.NewRouter().StrictSlash(true)
 	http.Handle("/", r)
-	return &Server{s, host, port, r}
+	return &Server{host, port, r}
 }
 
 func (s *Server) AddService(pathPrefix string, services *Service) {
-	s.AddRedirect(pathPrefix, pathPrefix+"/")
 	r := s.router.PathPrefix(pathPrefix).Subrouter()
 	for path, endpoint := range services.Routes {
 		(func(endpoint *Endpoint) {
-			r.HandleFunc(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { endpoint.Handle(s.Storage, w, r) }))
+			r.HandleFunc(path, endpoint.Handle)
 		})(endpoint)
 	}
 }

--- a/pkg/daemon/service.go
+++ b/pkg/daemon/service.go
@@ -2,10 +2,11 @@ package daemon
 
 import (
 	"encoding/json"
-	"github.com/Bitspark/slang/pkg/storage"
 	"io"
 	"log"
 	"net/http"
+
+	"github.com/Bitspark/slang/pkg/storage"
 )
 
 type Service struct {
@@ -13,7 +14,7 @@ type Service struct {
 }
 
 type Endpoint struct {
-	Handle func(st storage.Storage, w http.ResponseWriter, r *http.Request)
+	Handle func(w http.ResponseWriter, r *http.Request)
 }
 
 func getStorage(r *http.Request) storage.Storage {

--- a/pkg/daemon/service.go
+++ b/pkg/daemon/service.go
@@ -16,6 +16,14 @@ type Endpoint struct {
 	Handle func(st storage.Storage, w http.ResponseWriter, r *http.Request)
 }
 
+func getStorage(r *http.Request) storage.Storage {
+	return contextGet(r, "storage").(storage.Storage)
+}
+
+func contextGet(r *http.Request, key interface{}) interface{} {
+	return r.Context().Value(key)
+}
+
 func writeJSON(w io.Writer, dat interface{}) error {
 	return json.NewEncoder(w).Encode(dat)
 }

--- a/pkg/daemon/service.go
+++ b/pkg/daemon/service.go
@@ -17,8 +17,12 @@ type Endpoint struct {
 	Handle func(w http.ResponseWriter, r *http.Request)
 }
 
+type contextKey string
+
+const StorageKey contextKey = "storage"
+
 func getStorage(r *http.Request) storage.Storage {
-	return contextGet(r, "storage").(storage.Storage)
+	return contextGet(r, StorageKey).(storage.Storage)
 }
 
 func contextGet(r *http.Request, key interface{}) interface{} {

--- a/pkg/daemon/sharing_service.go
+++ b/pkg/daemon/sharing_service.go
@@ -4,16 +4,16 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"github.com/Bitspark/go-version"
-	"github.com/Bitspark/slang/pkg/storage"
-	"github.com/google/uuid"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/Bitspark/go-version"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v2"
 )
 
 type manifest struct {
@@ -27,7 +27,7 @@ type manifest struct {
 var suffixes = []string{"_visual.yaml"}
 
 var SharingService = &Service{map[string]*Endpoint{
-	"/export": {func(st storage.Storage, w http.ResponseWriter, r *http.Request) {
+	"/export": {func(w http.ResponseWriter, r *http.Request) {
 		fail := func(err *Error) {
 			sendFailure(w, &responseBad{err})
 		}
@@ -76,7 +76,7 @@ var SharingService = &Service{map[string]*Endpoint{
 			w.Write(buf.Bytes())
 		}
 	}},
-	"/import": {func(st storage.Storage, w http.ResponseWriter, r *http.Request) {
+	"/import": {func(w http.ResponseWriter, r *http.Request) {
 		fail := func(err *Error) {
 			sendFailure(w, &responseBad{err})
 		}


### PR DESCRIPTION
#### Hightlights of this change
This PR cleans how the deamon creates the http routes.

- introduction of `context` for `http.Request`
- less functionality on the `server`
- consistent `endpoint.Handle` signature
- added `strictSlash`