### PR TITLE
 Reengineer parts of the Storage to make it more consistent

### DIFF
--- a/cmd/makedocs/main.go
+++ b/cmd/makedocs/main.go
@@ -3,18 +3,19 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/Bitspark/go-funk"
-	"github.com/Bitspark/slang/pkg/core"
-	"github.com/Bitspark/slang/pkg/elem"
-	"github.com/Bitspark/slang/pkg/storage"
-	"github.com/google/uuid"
-	"github.com/stoewer/go-strcase"
 	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
 	"path"
 	"text/template"
+
+	"github.com/Bitspark/go-funk"
+	"github.com/Bitspark/slang/pkg/core"
+	"github.com/Bitspark/slang/pkg/elem"
+	"github.com/Bitspark/slang/pkg/storage"
+	"github.com/google/uuid"
+	"github.com/stoewer/go-strcase"
 )
 
 type TagInfo struct {

--- a/cmd/makedocs/main.go
+++ b/cmd/makedocs/main.go
@@ -165,7 +165,7 @@ func (dg *DocGenerator) collect(strict bool) {
 
 	elementaryUUIDs := elem.GetBuiltinIds()
 
-	store := storage.NewStorage(nil).AddLoader(storage.NewFileSystem(dg.libDir))
+	store := storage.NewStorage().AddBackend(storage.NewReadOnlyFileSystem(dg.libDir))
 
 	libraryUUIDs, err := store.List()
 	if err != nil {
@@ -482,7 +482,7 @@ func (dg *DocGenerator) saveURLs() {
 
 	written := 0
 
-	store := storage.NewStorage(storage.NewFileSystem(dg.libDir))
+	store := storage.NewStorage().AddBackend(storage.NewWritableFileSystem(dg.libDir))
 
 	for _, opInfo := range dg.generatedInfos {
 		if opInfo.Type != "library" {
@@ -501,7 +501,7 @@ func (dg *DocGenerator) saveURLs() {
 
 		opDef.Meta.DocURL = opDocURLStr
 
-		_, err := store.Store(opDef)
+		_, err := store.Save(opDef)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/Bitspark/slang/pkg/storage"
 	"log"
 	"net/http"
 	"os/user"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Bitspark/slang/pkg/storage"
 
 	"strconv"
 

--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -73,9 +73,9 @@ func main() {
 		log.Fatal("SLANG_LIB directory requires a sub directory 'slang/' containing all stdlib operators: ", dirSlib)
 	}
 
-	st := storage.
-		NewStorage(storage.NewFileSystem(envPaths.SLANG_DIR)).
-		AddLoader(storage.NewFileSystem(dirSlib))
+	st := storage.NewStorage().
+		AddBackend(storage.NewWritableFileSystem(envPaths.SLANG_DIR)).
+		AddBackend(storage.NewReadOnlyFileSystem(dirSlib))
 	srv := daemon.New(*st, "localhost", PORT)
 	envPaths.loadDaemonServices(srv)
 	envPaths.startDaemonServer(srv)

--- a/cmd/slangr/main.go
+++ b/cmd/slangr/main.go
@@ -5,11 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/Bitspark/go-funk"
-	"github.com/Bitspark/slang/pkg/api"
-	"github.com/Bitspark/slang/pkg/core"
-	"github.com/Bitspark/slang/pkg/storage"
-	"github.com/google/uuid"
 	"io"
 	"log"
 	"net"
@@ -17,6 +12,12 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+
+	"github.com/Bitspark/go-funk"
+	"github.com/Bitspark/slang/pkg/api"
+	"github.com/Bitspark/slang/pkg/core"
+	"github.com/Bitspark/slang/pkg/storage"
+	"github.com/google/uuid"
 )
 
 /*** (Loader *******/

--- a/cmd/slangr/main.go
+++ b/cmd/slangr/main.go
@@ -32,7 +32,7 @@ func newRunnerStorage(blueprints []core.OperatorDef) *storage.Storage {
 		m[bp.Id] = bp
 	}
 
-	return storage.NewStorage(nil).AddLoader(&runnerLoader{m})
+	return storage.NewStorage().AddBackend(&runnerLoader{m})
 }
 
 func (l *runnerLoader) Has(opId uuid.UUID) bool {

--- a/pkg/daemon/definition_service.go
+++ b/pkg/daemon/definition_service.go
@@ -2,12 +2,13 @@ package daemon
 
 import (
 	"encoding/json"
-	"github.com/Bitspark/slang/pkg/core"
-	"github.com/Bitspark/slang/pkg/elem"
-	"github.com/Bitspark/slang/pkg/storage"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/Bitspark/slang/pkg/core"
+	"github.com/Bitspark/slang/pkg/elem"
+	"github.com/Bitspark/slang/pkg/storage"
 )
 
 var DefinitionService = &Service{map[string]*Endpoint{

--- a/pkg/daemon/definition_service.go
+++ b/pkg/daemon/definition_service.go
@@ -56,7 +56,7 @@ var DefinitionService = &Service{map[string]*Endpoint{
 					}
 
 					opType := "library"
-					if st.IsDumpable(opId) {
+					if st.IsSavedInWritableBackend(opId) {
 						opType = "local"
 					}
 
@@ -99,7 +99,7 @@ var DefinitionService = &Service{map[string]*Endpoint{
 				return
 			}
 
-			_, err = e.Store(def)
+			_, err = e.Save(def)
 
 			if err != nil {
 				fail(&Error{Msg: err.Error(), Code: "E000X"})

--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -104,7 +104,7 @@ var RunnerService = &Service{map[string]*Endpoint{
 				return
 			}
 
-			st.AddLoader(&httpDefLoader{httpDef})
+			st.AddBackend(&httpDefLoader{httpDef})
 			httpDefId, _ := uuid.Parse(httpDef.Id)
 			op, err := api.BuildAndCompile(httpDefId, nil, nil, st)
 			if err != nil {

--- a/pkg/storage/fs.go
+++ b/pkg/storage/fs.go
@@ -3,16 +3,17 @@ package storage
 import (
 	"errors"
 	"fmt"
-	"github.com/Bitspark/go-funk"
-	"github.com/Bitspark/slang/pkg/core"
-	"github.com/Bitspark/slang/pkg/utils"
-	"github.com/google/uuid"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Bitspark/go-funk"
+	"github.com/Bitspark/slang/pkg/core"
+	"github.com/Bitspark/slang/pkg/utils"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v2"
 )
 
 var FILE_ENDINGS = []string{".yaml", ".yml", ".json"} // Order of endings matters!

--- a/pkg/storage/fs.go
+++ b/pkg/storage/fs.go
@@ -24,13 +24,27 @@ type FileSystem struct {
 	uuids []uuid.UUID
 }
 
-func NewFileSystem(p string) *FileSystem {
+type WritableFileSystem struct {
+	FileSystem
+}
+
+func cleanPath(p string) string {
 	pathSep := string(filepath.Separator)
 	p = filepath.Clean(p)
 	p, _ = filepath.Abs(p)
 	if !strings.HasSuffix(p, pathSep) {
 		p += pathSep
 	}
+	return p
+}
+
+func NewWritableFileSystem(root string) *WritableFileSystem {
+	p := cleanPath(root)
+	return &WritableFileSystem{FileSystem: FileSystem{p, make(map[uuid.UUID]*core.OperatorDef), nil}}
+}
+
+func NewReadOnlyFileSystem(root string) *FileSystem {
+	p := cleanPath(root)
 	return &FileSystem{p, make(map[uuid.UUID]*core.OperatorDef), nil}
 }
 
@@ -102,7 +116,7 @@ func (fs *FileSystem) Load(opId uuid.UUID) (*core.OperatorDef, error) {
 	return fs.Load(opId)
 }
 
-func (fs *FileSystem) Dump(opDef core.OperatorDef) (uuid.UUID, error) {
+func (fs *WritableFileSystem) Save(opDef core.OperatorDef) (uuid.UUID, error) {
 	opId, err := uuid.Parse(opDef.Id)
 
 	if err != nil {

--- a/pkg/storage/fs_test.go
+++ b/pkg/storage/fs_test.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Bitspark/slang/tests/assertions"
+)
+
+func Test_ReadOnlyFilesystem(t *testing.T) {
+	a := assertions.New(t)
+	fs := NewReadOnlyFileSystem("/somewhere")
+	a.Implements((*Backend)(nil), fs)
+}
+func Test_WriteableFilesystem(t *testing.T) {
+	a := assertions.New(t)
+	fs := NewWritableFileSystem("/somewhere")
+	a.Implements((*Backend)(nil), fs)
+	a.Implements((*WriteableBackend)(nil), fs)
+}
+
+func Test_cleanPath__AppendSlash(t *testing.T) {
+	a := assertions.New(t)
+	path := cleanPath("/tmp/folder")
+	a.Equal(path, "/tmp/folder/")
+}
+
+func Test_cleanPath__ExpandRelativePath(t *testing.T) {
+	cwd, _ := os.Getwd()
+	a := assertions.New(t)
+	path := cleanPath("folder")
+	// filepath.join stips trailing slash
+	a.Equal(path, filepath.Join(cwd, "folder")+"/")
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -68,7 +68,7 @@ func (s *Storage) Save(opDef core.OperatorDef) (uuid.UUID, error) {
 		return opId, errors.New("No writable backend for saving found")
 	}
 	for _, backend := range writableBackends {
-		opId, err = backend.(WriteableBackend).Save(opDef)
+		opId, err = backend.Save(opDef)
 	}
 	return opId, err
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+
 	"github.com/Bitspark/slang/pkg/core"
 	"github.com/Bitspark/slang/pkg/elem"
 	"github.com/google/uuid"

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -108,7 +108,7 @@ func (s *Storage) selectBackends(f func(Backend) bool) []Backend {
 func (s *Storage) selectBackend(opId uuid.UUID) Backend {
 	backends := s.selectBackends(func(b Backend) bool { return b.Has(opId) })
 	if len(backends) > 0 {
-		return backends[0] // always return the first backend they
+		return backends[0] // always return the first backend as there should not be different version of the same operator.
 	}
 	return nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Bitspark/slang/pkg/core"
@@ -8,54 +9,45 @@ import (
 	"github.com/google/uuid"
 )
 
-type Loader interface {
+type Backend interface {
 	List() ([]uuid.UUID, error)
-	Has(opId uuid.UUID) bool
 	Load(opId uuid.UUID) (*core.OperatorDef, error)
+	Has(opId uuid.UUID) bool
 }
 
-type LoaderDumper interface {
-	List() ([]uuid.UUID, error)
-	Load(opId uuid.UUID) (*core.OperatorDef, error)
-	Dump(opDef core.OperatorDef) (uuid.UUID, error)
-	Has(opId uuid.UUID) bool
+type WriteableBackend interface {
+	Backend
+	Save(opDef core.OperatorDef) (uuid.UUID, error)
 }
 
 type Storage struct {
-	loader []Loader
-	dumper LoaderDumper
+	backends []Backend
 }
 
-func NewStorage(ld LoaderDumper) *Storage {
-	st := &Storage{make([]Loader, 0), nil}
-
-	if ld != nil {
-		st.dumper = ld
-		st.AddLoader(ld)
-	}
-
-	return st
+func NewStorage() *Storage {
+	return &Storage{make([]Backend, 0)}
 }
 
-func (s *Storage) AddLoader(loader Loader) *Storage {
-	s.loader = append(s.loader, loader)
+func (s *Storage) AddBackend(backend Backend) *Storage {
+	s.backends = append(s.backends, backend)
 	return s
 }
 
-func (s *Storage) IsDumpable(opId uuid.UUID) bool {
-	return s.dumper.Has(opId)
-}
-
-func (s *Storage) IsLoadable(opId uuid.UUID) bool {
-	loader := s.findRelatedLoader(opId)
-	return loader != nil
+func (s *Storage) IsSavedInWritableBackend(opId uuid.UUID) bool {
+	writableBackends := s.writeableBackends()
+	for _, backend := range writableBackends {
+		if backend.Has(opId) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Storage) List() ([]uuid.UUID, error) {
 	all := make([]uuid.UUID, 0)
 
-	for _, loader := range s.loader {
-		l, err := loader.List()
+	for _, backend := range s.backends {
+		l, err := backend.List()
 
 		if err != nil {
 			continue
@@ -66,12 +58,36 @@ func (s *Storage) List() ([]uuid.UUID, error) {
 	return all, nil
 }
 
-func (s *Storage) Store(opDef core.OperatorDef) (uuid.UUID, error) {
-	return s.dumper.Dump(opDef)
+func (s *Storage) Save(opDef core.OperatorDef) (uuid.UUID, error) {
+	var opId uuid.UUID
+	var err error
+	// The question is whether we want multiple backends that are able to take a write
+	// because if we need to make sure they all use the same identifier
+	writableBackends := s.writeableBackends()
+	if len(writableBackends) == 0 {
+		return opId, errors.New("No writable backend for saving found")
+	}
+	for _, backend := range writableBackends {
+		opId, err = backend.(WriteableBackend).Save(opDef)
+	}
+	return opId, err
+}
+
+func (s *Storage) writeableBackends() []WriteableBackend {
+	writeableBackends := make([]WriteableBackend, 0)
+
+	backends := s.selectBackends(func(b Backend) bool {
+		b, ok := b.(WriteableBackend)
+		return ok
+	})
+	for _, backend := range backends {
+		writeableBackends = append(writeableBackends, backend.(WriteableBackend))
+	}
+	return writeableBackends
 }
 
 func (s *Storage) Load(opId uuid.UUID) (*core.OperatorDef, error) {
-	opDef, err := s.loadFirstFound(opId)
+	opDef, err := s.getOpDef(opId)
 	if err != nil {
 		return nil, err
 	}
@@ -79,27 +95,36 @@ func (s *Storage) Load(opId uuid.UUID) (*core.OperatorDef, error) {
 	return &cpyOpDef, nil
 }
 
-func (s *Storage) findRelatedLoader(opId uuid.UUID) Loader {
-	for _, loader := range s.loader {
-		if loader.Has(opId) {
-			return loader
+func (s *Storage) selectBackends(f func(Backend) bool) []Backend {
+	selected := make([]Backend, 0)
+	for _, backend := range s.backends {
+		if f(backend) {
+			selected = append(selected, backend)
 		}
+	}
+	return selected
+}
+
+func (s *Storage) selectBackend(opId uuid.UUID) Backend {
+	backends := s.selectBackends(func(b Backend) bool { return b.Has(opId) })
+	if len(backends) > 0 {
+		return backends[0] // always return the first backend they
 	}
 	return nil
 }
 
-func (s *Storage) loadFirstFound(opId uuid.UUID) (*core.OperatorDef, error) {
+func (s *Storage) getOpDef(opId uuid.UUID) (*core.OperatorDef, error) {
 	if opDef, err := elem.GetOperatorDef(opId.String()); err == nil {
 		return opDef, nil
 	}
 
-	loader := s.findRelatedLoader(opId)
+	backend := s.selectBackend(opId)
 
-	if loader == nil {
+	if backend == nil {
 		return nil, fmt.Errorf("unknown operator for id: %s", opId)
 	}
 
-	opDef, err := loader.Load(opId)
+	opDef, err := backend.Load(opId)
 
 	if err != nil {
 		return nil, err

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/Bitspark/slang/pkg/core"
+	"github.com/Bitspark/slang/tests/assertions"
+	"github.com/google/uuid"
+)
+
+func Test_ReadOnlyStorage(t *testing.T) {
+	a := assertions.New(t)
+	s := NewStorage().AddBackend(NewReadOnlyFileSystem("/somewhere"))
+	w := s.writeableBackends()
+	a.Empty(w)
+}
+
+func Test_WritableStorage(t *testing.T) {
+	a := assertions.New(t)
+	s := NewStorage()
+	s.AddBackend(NewWritableFileSystem("/somewhere"))
+	s.AddBackend(NewWritableFileSystem("/somewhere"))
+	s.AddBackend(NewReadOnlyFileSystem("/somewhere"))
+	s.AddBackend(NewReadOnlyFileSystem("/somewhere"))
+	w := s.writeableBackends()
+	a.Len(w, 2)
+}
+
+func Test_SavingWithoutWritableBackend(t *testing.T) {
+	var u uuid.UUID //empty UUID
+	a := assertions.New(t)
+	s := NewStorage().AddBackend(NewReadOnlyFileSystem("/somewhere"))
+	id, err := s.Save(core.OperatorDef{})
+	a.Equal(id, u)
+	a.EqualError(err, "No writable backend for saving found")
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4,6 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/Bitspark/go-funk"
 	"github.com/Bitspark/slang/pkg/api"
 	"github.com/Bitspark/slang/pkg/core"
@@ -11,11 +17,6 @@ import (
 	"github.com/Bitspark/slang/pkg/storage"
 	"github.com/Bitspark/slang/pkg/utils"
 	"github.com/google/uuid"
-	"io"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 func parseJSON(str string) interface{} {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -195,5 +195,5 @@ func (t testEnv) CompileFile(opFile string, gens map[string]*core.TypeDef, props
 const testdir string = "./"
 
 var tl = NewTestLoader(testdir)
-var st = storage.NewStorage(nil).AddLoader(tl)
+var st = storage.NewStorage().AddBackend(tl)
 var Test = testEnv{testdir, tl, st}


### PR DESCRIPTION
This included renaming methods to better suit the concept e.g. `Load`
and `Save` instead of `Dump`.

A small highlight is the `interface` based distinction between writeable
and readonly backends. Which led to more renaming. It also got rid of
the distinction between `loader` and `dumper` which are now handeld
through a single backend.

It also makes the API a bit more consice as do not longer need to know
that the loader pass into the constructer become the dumper.

Now you can control whether a `backend` is able to recieve writes by
implementing `Save` and thus conforming to the `WriteableBackend`
`interface`.