### PR TITLE
Introduce `Enviroment` to hold outside configuration for the daemon and others

### DIFF
--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -55,9 +55,9 @@ func main() {
 	}
 
 	st := storage.NewStorage().
-		AddBackend(storage.NewWritableFileSystem(envPaths.SLANG_DIR)).
-		AddBackend(storage.NewReadOnlyFileSystem(dirSlib))
-	srv := daemon.New("localhost", PORT)
+		AddBackend(storage.NewWritableFileSystem(env.SLANG_DIR)).
+		AddBackend(storage.NewReadOnlyFileSystem(env.SLANG_LIB))
+	srv := daemon.NewServer(env)
 	ctx := context.WithValue(context.Background(), daemon.StorageKey, *st)
 
 	if !withoutUI {

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/Bitspark/slang/pkg/env"
+
 	"github.com/rs/cors"
 
 	"github.com/gorilla/mux"
@@ -27,7 +29,7 @@ func addContext(ctx context.Context, next http.Handler) http.Handler {
 func New(host string, port int) *Server {
 	r := mux.NewRouter().StrictSlash(true)
 	http.Handle("/", r)
-	srv := &Server{host, port, r}
+	srv := &Server{env.HTTP.Address, env.HTTP.Port, r}
 	srv.mountWebServices()
 	return srv
 }

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -27,7 +27,16 @@ func addContext(ctx context.Context, next http.Handler) http.Handler {
 func New(host string, port int) *Server {
 	r := mux.NewRouter().StrictSlash(true)
 	http.Handle("/", r)
-	return &Server{host, port, r}
+	srv := &Server{host, port, r}
+	srv.mountWebServices()
+	return srv
+}
+
+func (s *Server) mountWebServices() {
+	s.AddService("/operator", DefinitionService)
+	s.AddService("/run", RunnerService)
+	s.AddService("/share", SharingService)
+	s.AddOperatorProxy("/instance")
 }
 
 func (s *Server) AddService(pathPrefix string, services *Service) {

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -26,7 +26,7 @@ func addContext(ctx context.Context, next http.Handler) http.Handler {
 	})
 }
 
-func New(host string, port int) *Server {
+func NewServer(env *env.Environment) *Server {
 	r := mux.NewRouter().StrictSlash(true)
 	http.Handle("/", r)
 	srv := &Server{env.HTTP.Address, env.HTTP.Port, r}

--- a/pkg/env/environment.go
+++ b/pkg/env/environment.go
@@ -1,0 +1,67 @@
+package env
+
+import (
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/Bitspark/slang/pkg/utils"
+)
+
+// Holds configuration for the web parts
+type httpCfg struct {
+	Address string
+	Port    int
+}
+
+type Environment struct {
+	SLANG_PATH          string
+	SLANG_DIR           string
+	SLANG_LIB_REPO_PATH string
+	SLANG_LIB           string
+	SLANG_UI            string
+
+	HTTP httpCfg
+}
+
+func ensureEnvironVar(key string, dfltVal string) string {
+	if val := os.Getenv(key); strings.Trim(val, " ") != "" {
+		return val
+	}
+	os.Setenv(key, dfltVal)
+	return dfltVal
+}
+
+func New(addr string, port int) *Environment {
+	currUser, err := user.Current()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	slangPath := filepath.Join(currUser.HomeDir, "slang")
+
+	e := &Environment{
+		slangPath,
+		ensureEnvironVar("SLANG_DIR", filepath.Join(slangPath, "projects")),
+		ensureEnvironVar("SLANG_LIB_REPO_PATH", filepath.Join(slangPath, "lib")),
+		ensureEnvironVar("SLANG_LIB", filepath.Join(slangPath, "lib", "slang")),
+		ensureEnvironVar("SLANG_UI", filepath.Join(slangPath, "ui")),
+		httpCfg{Address: addr, Port: port},
+	}
+
+	if _, err = utils.EnsureDirExists(e.SLANG_DIR); err != nil {
+		log.Fatal(err)
+	}
+	// we do not need to check the REPO as it will be present after
+	// ensuring `SLANG_LIB` exists
+	if _, err = utils.EnsureDirExists(e.SLANG_LIB); err != nil {
+		log.Fatal(err)
+	}
+	if _, err = utils.EnsureDirExists(e.SLANG_UI); err != nil {
+		log.Fatal(err)
+	}
+
+	return e
+}


### PR DESCRIPTION
This is intented to serve as global `struct` that can be passed around or instantiated over and over again containing the initial config.