### PR TITLE
Websocket basics.

### DIFF
--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -126,8 +126,6 @@ var RunnerService = &Service{map[string]*Endpoint{
 			op.Main().In().Push(nil) // Start server
 			hub.broadCastTo(Root, "Starting Operator")
 
-			//ConnectedClients[Root].C <- []byte("Starting operator")
-
 			data.Status = "success"
 			data.Handle = strconv.FormatInt(handle, 16)
 			data.URL = "/instance/" + strconv.FormatInt(handle, 16)

--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -43,9 +43,9 @@ func (l *httpDefLoader) Load(opId uuid.UUID) (*core.OperatorDef, error) {
 
 var RunnerService = &Service{map[string]*Endpoint{
 	"/": {func(w http.ResponseWriter, r *http.Request) {
+		hub := GetHub(r)
 		st := GetStorage(r)
 		if r.Method == "POST" {
-			hub := r.Context().Value("hub").(*Hub)
 			type runInstructionJSON struct {
 				Id     string          `json:"id"`
 				Props  core.Properties `json:"props"`

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -189,7 +189,7 @@ func (c *ConnectedClient) waitOnOutgoing() {
 }
 
 func serveWs(w http.ResponseWriter, r *http.Request) {
-	hub := r.Context().Value("hub").(*Hub)
+	hub := GetHub(r)
 	user := Root
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -234,7 +234,7 @@ func (s *Server) AddWebsocket(path string) {
 	// Don't know yet if that is good idea
 	// Maybe should make the `hub` a singleton instead of shoving it
 	// into the context where it needs more typing to be safe
-	newCtx := context.WithValue(*s.ctx, "hub", hub)
+	newCtx := SetHub(*s.ctx, hub)
 	s.ctx = &newCtx
 	go hub.run()
 }

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -1,18 +1,43 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"net/http"
+	"time"
 
 	"github.com/Bitspark/slang/pkg/env"
 
 	"github.com/rs/cors"
 
 	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
 )
 
 var SlangVersion string
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+
+	// Maximum message size allowed from peer.
+	maxMessageSize = 512
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	// allow every host/origin to make a connection e.g. :8080 -> 5149
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
 
 type Server struct {
 	Host   string
@@ -35,11 +60,71 @@ func NewServer(ctx *context.Context, env *env.Environment) *Server {
 	return srv
 }
 
+func (s *Server) AddWebsocket(path string) {
+	r := s.router.Path(path)
+	r.HandlerFunc(serveWs)
+}
+
+func reader(ws *websocket.Conn) {
+	newline := []byte{'\n'}
+	space := []byte{' '}
+	defer ws.Close()
+	ws.SetReadLimit(maxMessageSize)
+	ws.SetReadDeadline(time.Now().Add(pongWait))
+	ws.SetPongHandler(func(string) error { ws.SetReadDeadline(time.Now().Add(pongWait)); return nil })
+
+	for {
+		_, message, err := ws.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				log.Printf("error: %v", err)
+			}
+			break
+		}
+		message = bytes.TrimSpace(bytes.Replace(message, newline, space, -1))
+		log.Printf("Got Message: %v", message)
+	}
+}
+
+func writer(ws *websocket.Conn) {
+	ticker := time.NewTicker(pingPeriod)
+	helloTicker := time.NewTicker(1 * time.Second)
+	defer func() {
+		ticker.Stop()
+		ws.Close()
+	}()
+	for {
+		select {
+		case <-helloTicker.C:
+			ws.SetWriteDeadline(time.Now().Add(writeWait))
+			ws.WriteMessage(websocket.TextMessage, []byte("Hello"))
+		case <-ticker.C:
+			ws.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := ws.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func serveWs(w http.ResponseWriter, r *http.Request) {
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		if _, ok := err.(websocket.HandshakeError); !ok {
+			log.Println(err)
+		}
+		return
+	}
+	go writer(ws)
+	go reader(ws)
+}
+
 func (s *Server) mountWebServices() {
 	s.AddService("/operator", DefinitionService)
 	s.AddService("/run", RunnerService)
 	s.AddService("/share", SharingService)
 	s.AddOperatorProxy("/instance")
+	s.AddWebsocket("/ws")
 }
 
 func (s *Server) AddService(pathPrefix string, services *Service) {

--- a/pkg/daemon/service.go
+++ b/pkg/daemon/service.go
@@ -23,7 +23,7 @@ type contextKey string
 const StorageKey contextKey = "storage"
 
 func GetStorage(r *http.Request) storage.Storage {
-	return contextGet(r, StorageKey).(storage.Storage)
+	return *contextGet(r, StorageKey).(*storage.Storage)
 }
 
 func SetStorage(ctx context.Context, st *storage.Storage) context.Context {

--- a/pkg/daemon/service.go
+++ b/pkg/daemon/service.go
@@ -20,14 +20,23 @@ type Endpoint struct {
 
 type contextKey string
 
-const StorageKey contextKey = "storage"
+const storageKey contextKey = "storage"
+const hubKey contextKey = "hub"
 
 func GetStorage(r *http.Request) storage.Storage {
-	return *contextGet(r, StorageKey).(*storage.Storage)
+	return *contextGet(r, storageKey).(*storage.Storage)
+}
+
+func SetHub(ctx context.Context, h *Hub) context.Context {
+	return context.WithValue(ctx, hubKey, h)
+}
+
+func GetHub(r *http.Request) *Hub {
+	return contextGet(r, hubKey).(*Hub)
 }
 
 func SetStorage(ctx context.Context, st *storage.Storage) context.Context {
-	return context.WithValue(ctx, StorageKey, st)
+	return context.WithValue(ctx, storageKey, st)
 }
 
 func contextGet(r *http.Request, key interface{}) interface{} {


### PR DESCRIPTION
Introducing websockets.

This PR add websocket capabilities to the daemon or to be more specific to the webserver under `/ws`. It use gorilla/websocket to accomplish much of the heavy lifting. Although we still have to explictly keep the `ping<>pong`.

Apart from just having it serve a websocket this PR also introduces an API to work with connected client under the assumpation that a user can have more than one connection/browser open at any given time. Which is way we cannot pass around a single channel but rather a `Hub` which manages all currently connected client on a `User` bases. 

At the moment we don't have the concept of a user that is why there is the `Root` which is assigned to any incoming connection. But having that in the first place makes it easier to think in terms of what the code must be able to do in a multi tenant environment. 

The `Hub` is currently attached to the context and can be used to broadcast message to a `user`.

#### Usage
```golang
hub := GetHub(r) // where r is *http.Request
hub.broadCastTo(Root, "Starting Operator")  // this send a message to all connected clients that belong to Root
```

This is how the implementation looks on the frontend side of things https://github.com/Bitspark/slang-studio/pull/96.