### PR TITLE
Adding basic linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,18 @@
 version: 2
 jobs:
+  lint:
+    docker:
+      - image: bitspark/slang-ci:latest
+    working_directory: /gopath/src/github.com/Bitspark/slang/
+    steps:
+      - checkout
+      - run:
+          name: Get dependencies
+          command: go get -v -t -d ./...
+      - run:
+          name: lint
+          command: |
+            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
   test:
     docker:
       - image: bitspark/slang-ci:latest
@@ -11,7 +24,7 @@ jobs:
           command: go get -v -t -d ./...
       - run:
           name: Test
-          command: | 
+          command: |
             go test -coverprofile=coverage.txt -covermode=atomic -v ./...
             bash <(curl -s https://codecov.io/bash)
   build:
@@ -47,10 +60,16 @@ workflows:
   version: 2
   build-and-release:
     jobs:
+      - lint:
+          filters:
+            tags:
+              only: /.*/
       - test:
           filters:
             tags:
               only: /.*/
+          requires:
+            - lint
       - build:
           requires:
             - test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 1m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: true
+
+# all available settings of specific linters
+linters:
+  enable:
+    - deadcode
+    - govet
+    - unconvert
+
+  disable-all: true
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+  # It's a super-useful option for integration of golangci-lint into existing
+  # large codebase. It's not practical to fix all existing issues at the moment
+  # of integration: much better don't allow issues in new code.
+  # Default is false.
+  new: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,13 +15,30 @@ run:
   # include test files or not, default is true
   tests: true
 
+issues:
+  # List of regexps of issue texts to exclude, empty list by default.
+  # But independently from this option we use default exclude patterns,
+  # it can be disabled by `exclude-use-default: false`. To list all
+  # excluded by default patterns execute `golangci-lint run --help`
+  # exclude:
+  #   - abcdef
+
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: cmd/makedocs/.*\.go
+      linters:
+        - unused
+
 # all available settings of specific linters
 linters:
   enable:
     - deadcode
     - govet
     - unconvert
+    - staticcheck
     - gofmt
+    - unused
 
   disable-all: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ linters:
     - unused
     - unparam
     - scopelint
+    - structcheck
 
   disable-all: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - varcheck
     - unused
     - unparam
+    - scopelint
 
   disable-all: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - deadcode
     - govet
     - unconvert
+    - gofmt
 
   disable-all: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,9 @@ linters:
     - unconvert
     - staticcheck
     - gofmt
+    - varcheck
     - unused
+    - unparam
 
   disable-all: true
 

--- a/cmd/makedocs/main.go
+++ b/cmd/makedocs/main.go
@@ -495,6 +495,7 @@ func (dg *DocGenerator) saveURLs() {
 		opDocURL.Path = path.Join(opDocURL.Path, opInfo.Slug)
 		opDocURLStr := opDocURL.String()
 
+		//nolint:staticcheck
 		if opDef.Meta.DocURL == opDocURLStr {
 			// continue
 		}

--- a/cmd/slang/main.go
+++ b/cmd/slang/main.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/Bitspark/slang/pkg/api"
-	"github.com/Bitspark/slang/pkg/core"
 	"io"
 	"io/ioutil"
 	"log"
@@ -14,6 +12,9 @@ import (
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/Bitspark/slang/pkg/api"
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var printPorts bool
@@ -65,6 +66,7 @@ func printPortDef(slFile *core.SlangFileDef) error {
 	mainBpId := slFile.Main
 	var opDef *core.OperatorDef
 	for _, bp := range slFile.Blueprints {
+		bp := bp
 		if mainBpId == bp.Id {
 			opDef = &bp
 		}

--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -66,7 +66,7 @@ func main() {
 		srv.AddStaticServer("/app", http.Dir(env.SLANG_UI))
 	}
 
-	startDaemonServer(ctx, srv)
+	startDaemonServer(srv)
 }
 
 func checkNewestVersion() {
@@ -113,7 +113,7 @@ func loadLocalComponents(e *env.Environment) {
 	}
 }
 
-func startDaemonServer(ctx context.Context, srv *daemon.Server) {
+func startDaemonServer(srv *daemon.Server) {
 	url := fmt.Sprintf("http://%s:%d/", srv.Host, srv.Port)
 	errors := make(chan error)
 	go informUser(url, errors)

--- a/cmd/slangr/main.go
+++ b/cmd/slangr/main.go
@@ -127,12 +127,15 @@ func (w *wrkCmds) Init(a string) (string, error) {
 	return w.PrtCfg()
 }
 
+//nolint:staticcheck
 func (w *wrkCmds) PrtCfg() (string, error) {
 	if w.op == nil {
 		return "", fmt.Errorf("runner is not initialized: provide valid operator")
 	}
 
 	// todo timeout to prevent infinite loop
+	// this us a race condition because `w.sp` changes outside of
+	// the current function - better use channels here.
 	for w.sp == nil {
 	}
 

--- a/pkg/core/def.go
+++ b/pkg/core/def.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"regexp"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 type InstanceDefList []*InstanceDef

--- a/pkg/core/port.go
+++ b/pkg/core/port.go
@@ -705,67 +705,6 @@ func (p *Port) Name() string {
 	}
 
 	return p.StringifyComplete()
-
-	var name string
-
-	if p.parMap != nil {
-		for pn, pt := range p.parMap.subs {
-			if pt == p {
-				name = "[" + pn + "]"
-			}
-		}
-	}
-
-	switch p.itemType {
-	case TYPE_GENERIC:
-		name += "_GENERIC"
-	case TYPE_PRIMITIVE:
-		name += "_PRIMITIVE"
-	case TYPE_TRIGGER:
-		name += "_TRIGGER"
-	case TYPE_NUMBER:
-		name += "_NUMBER"
-	case TYPE_STRING:
-		name += "_STRING"
-	case TYPE_BINARY:
-		name += "_BINARY"
-	case TYPE_BOOLEAN:
-		name += "_BOOLEAN"
-	case TYPE_MAP:
-		name += "_MAP"
-	case TYPE_STREAM:
-		name += "_STREAM"
-	}
-
-	if p.parMap != nil {
-		return p.parMap.Name() + name
-	}
-
-	if p.parStr != nil {
-		return p.parStr.Name() + name
-	}
-
-	if p.direction == DIRECTION_IN {
-		if p.operator != nil {
-			if p.delegate != nil {
-				return p.operator.name + "." + p.delegate.name + ":IN" + name
-			} else {
-				return p.operator.name + ":IN" + name
-			}
-		} else {
-			return "IN_" + name
-		}
-	} else {
-		if p.operator != nil {
-			if p.delegate != nil {
-				return p.operator.name + "." + p.delegate.name + ":OUT" + name
-			} else {
-				return p.operator.name + ":OUT" + name
-			}
-		} else {
-			return "OUT" + name
-		}
-	}
 }
 
 func (p *Port) Bufferize() {

--- a/pkg/daemon/component_loader.go
+++ b/pkg/daemon/component_loader.go
@@ -104,6 +104,9 @@ func (dl *SlangComponentLoader) updateLocalVersionFile() error {
 
 func (dl *SlangComponentLoader) downloadArchiveAndUnpack(archiveURL string) error {
 	archiveFilePath, err := dl.download(archiveURL)
+	if err != nil {
+		return err
+	}
 	// Unpack archive into directory
 	tmpDstDir, err := ioutil.TempDir("", dl.repo)
 	if err != nil {
@@ -170,11 +173,11 @@ func (dl *SlangComponentLoader) GetLocalReleaseVersion() *version.Version {
 		return nil
 	}
 	versionFile, err := os.Open(dl.versionFilePath)
-	defer versionFile.Close()
-
 	if err != nil {
 		return nil
 	}
+
+	defer versionFile.Close()
 
 	versionReader := bufio.NewReader(versionFile)
 	currVersion, _, err := versionReader.ReadLine()

--- a/pkg/daemon/component_loader.go
+++ b/pkg/daemon/component_loader.go
@@ -115,9 +115,6 @@ func (dl *SlangComponentLoader) downloadArchiveAndUnpack(archiveURL string) erro
 	defer os.Remove(archiveFilePath)
 	defer os.RemoveAll(tmpDstDir)
 
-	if err != nil {
-		return err
-	}
 	if err = dl.replaceDirContentBy(tmpDstDir); err != nil {
 		return err
 	}

--- a/pkg/daemon/proxy.go
+++ b/pkg/daemon/proxy.go
@@ -48,7 +48,7 @@ func proxyRequestToOperator(w http.ResponseWriter, r *http.Request) {
 	newURL.Path = newPath
 	newURL.RawQuery = r.URL.RawQuery
 
-	req, err := http.NewRequest(r.Method, newURL.String(), r.Body)
+	req, _ := http.NewRequest(r.Method, newURL.String(), r.Body)
 	for key := range r.Header {
 		req.Header.Set(key, r.Header.Get(key))
 	}

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -33,6 +33,7 @@ func New(host string, port int) *Server {
 func (s *Server) AddService(pathPrefix string, services *Service) {
 	r := s.router.PathPrefix(pathPrefix).Subrouter()
 	for path, endpoint := range services.Routes {
+		path := path
 		(func(endpoint *Endpoint) {
 			r.HandleFunc(path, endpoint.Handle)
 		})(endpoint)

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -41,7 +41,7 @@ func (s *Server) AddService(pathPrefix string, services *Service) {
 
 func (s *Server) AddStaticServer(pathPrefix string, directory http.Dir) {
 	r := s.router.PathPrefix(pathPrefix)
-	r.Handler(http.StripPrefix(pathPrefix, http.FileServer(http.Dir(directory))))
+	r.Handler(http.StripPrefix(pathPrefix, http.FileServer(directory)))
 }
 
 func (s *Server) AddOperatorProxy(pathPrefix string) {

--- a/pkg/daemon/sharing_service.go
+++ b/pkg/daemon/sharing_service.go
@@ -5,10 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/Bitspark/go-version"
@@ -21,10 +18,8 @@ type manifest struct {
 	TimeUnix     int64  `yaml:"timeUnix"`
 }
 
-/* TODO re-implemet this service
+/* TODO re-implements this service
  */
-
-var suffixes = []string{"_visual.yaml"}
 
 var SharingService = &Service{map[string]*Endpoint{
 	"/export": {func(w http.ResponseWriter, r *http.Request) {
@@ -124,25 +119,6 @@ var SharingService = &Service{map[string]*Endpoint{
 
 			fail(&Error{Msg: "not implemented yet", Code: "E000X"})
 			return
-
-			baseDir := "" // st.WorkingDir()
-			for _, file := range zipReader.File {
-				if file.Name == "manifest.yaml" {
-					continue
-				}
-
-				fileReader, _ := file.Open()
-				buf := new(bytes.Buffer)
-				buf.ReadFrom(fileReader)
-				fpath := filepath.Join(baseDir, filepath.FromSlash(file.Name))
-				os.MkdirAll(filepath.Dir(fpath), os.ModePerm)
-				ioutil.WriteFile(fpath, buf.Bytes(), os.ModePerm)
-				fileReader.Close()
-			}
-
-			writeJSON(w, &struct {
-				Success bool `json:"success"`
-			}{true})
 		}
 	}},
 }}

--- a/pkg/elem/data_evaluate.go
+++ b/pkg/elem/data_evaluate.go
@@ -25,7 +25,7 @@ func floatify(val interface{}) (float64, bool) {
 type mathFunc1 func(float64) float64
 type mathFunc2 func(float64, float64) float64
 
-func makeMathFunc1(f mathFunc1, args ...interface{}) govaluate.ExpressionFunction {
+func makeMathFunc1(f mathFunc1) govaluate.ExpressionFunction {
 	return func(args ...interface{}) (interface{}, error) {
 		if fval, ok := floatify(args[0]); ok {
 			return f(fval), nil
@@ -34,7 +34,7 @@ func makeMathFunc1(f mathFunc1, args ...interface{}) govaluate.ExpressionFunctio
 	}
 }
 
-func makeMathFunc2(f mathFunc2, args ...interface{}) govaluate.ExpressionFunction {
+func makeMathFunc2(f mathFunc2) govaluate.ExpressionFunction {
 	return func(args ...interface{}) (interface{}, error) {
 		fval1, ok1 := floatify(args[0])
 		fval2, ok2 := floatify(args[1])

--- a/pkg/elem/database_query.go
+++ b/pkg/elem/database_query.go
@@ -1,8 +1,8 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"database/sql"
+	"github.com/Bitspark/slang/pkg/core"
 	_ "github.com/go-sql-driver/mysql"
 	"reflect"
 )
@@ -11,11 +11,11 @@ var databaseQueryCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "ce3a3e0e-d579-4712-8573-713a645c2271",
 		Meta: core.OperatorMetaDef{
-			Name: "DB query",
+			Name:             "DB query",
 			ShortDescription: "queries an SQL query on a relational database and emits the result set",
-			Icon: "database",
-			Tags: []string{"database"},
-			DocURL: "https://bitspark.de/slang/docs/operator/db-execute",
+			Icon:             "database",
+			Tags:             []string{"database"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/db-execute",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/database_redis_get.go
+++ b/pkg/elem/database_redis_get.go
@@ -9,11 +9,11 @@ var databaseRedisGetCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "362482c1-2021-4e5c-9463-b580a6c1967e",
 		Meta: core.OperatorMetaDef{
-			Name: "Redis Get",
+			Name:             "Redis Get",
 			ShortDescription: "executes a Get command at the specified Redis server",
-			Icon: "database",
-			Tags: []string{"database", "redis"},
-			DocURL: "https://bitspark.de/slang/docs/operator/redis-get",
+			Icon:             "database",
+			Tags:             []string{"database", "redis"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/redis-get",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/database_redis_hget.go
+++ b/pkg/elem/database_redis_hget.go
@@ -9,11 +9,11 @@ var databaseRedisHGetCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "4b946e4a-e26b-45c7-9759-c60bd57d190d",
 		Meta: core.OperatorMetaDef{
-			Name: "Redis HGet",
+			Name:             "Redis HGet",
 			ShortDescription: "executes an HGet command at the specified Redis server",
-			Icon: "database",
-			Tags: []string{"database", "redis"},
-			DocURL: "https://bitspark.de/slang/docs/operator/redis-hget",
+			Icon:             "database",
+			Tags:             []string{"database", "redis"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/redis-hget",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/database_redis_hincrby.go
+++ b/pkg/elem/database_redis_hincrby.go
@@ -9,11 +9,11 @@ var databaseRedisHIncrByCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "8d9e4c6e-20a2-44b1-8d51-ed98f4d3b4d8",
 		Meta: core.OperatorMetaDef{
-			Name: "Redis HIncr",
+			Name:             "Redis HIncr",
 			ShortDescription: "executes an HIncr command at the specified Redis server",
-			Icon: "database",
-			Tags: []string{"database", "redis"},
-			DocURL: "https://bitspark.de/slang/docs/operator/redis-hincrby",
+			Icon:             "database",
+			Tags:             []string{"database", "redis"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/redis-hincrby",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/database_redis_hset.go
+++ b/pkg/elem/database_redis_hset.go
@@ -9,11 +9,11 @@ var databaseRedisHSetCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "a6b45f70-e20c-40a5-ac39-c00068d10c81",
 		Meta: core.OperatorMetaDef{
-			Name: "Redis HSet",
+			Name:             "Redis HSet",
 			ShortDescription: "executes an HSet command at the specified Redis server",
-			Icon: "database",
-			Tags: []string{"database", "redis"},
-			DocURL: "https://bitspark.de/slang/docs/operator/redis-hset",
+			Icon:             "database",
+			Tags:             []string{"database", "redis"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/redis-hset",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/database_redis_lpush.go
+++ b/pkg/elem/database_redis_lpush.go
@@ -9,11 +9,11 @@ var databaseRedisLPushCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "8f8a095c-9274-4d39-96d9-3ef463659426",
 		Meta: core.OperatorMetaDef{
-			Name: "Redis LPush",
+			Name:             "Redis LPush",
 			ShortDescription: "executes an LPush command at the specified Redis server",
-			Icon: "database",
-			Tags: []string{"database", "redis"},
-			DocURL: "https://bitspark.de/slang/docs/operator/redis-lpush",
+			Icon:             "database",
+			Tags:             []string{"database", "redis"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/redis-lpush",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/database_redis_set.go
+++ b/pkg/elem/database_redis_set.go
@@ -1,20 +1,21 @@
 package elem
 
 import (
+	"time"
+
 	"github.com/Bitspark/slang/pkg/core"
 	"github.com/go-redis/redis"
-	"time"
 )
 
 var databaseRedisSetCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "cdbf3e0d-1ce0-4565-9df6-d0e829c730e5",
 		Meta: core.OperatorMetaDef{
-			Name: "Redis Set",
+			Name:             "Redis Set",
 			ShortDescription: "executes a Set command at the specified Redis server",
-			Icon: "database",
-			Tags: []string{"database", "redis"},
-			DocURL: "https://bitspark.de/slang/docs/operator/redis-set",
+			Icon:             "database",
+			Tags:             []string{"database", "redis"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/redis-set",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/encoding_url_write.go
+++ b/pkg/elem/encoding_url_write.go
@@ -1,20 +1,21 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
-	"net/url"
 	"fmt"
+	"net/url"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var encodingURLWriteCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "702a2036-a1cc-4783-8b83-b18494c5e9f1",
 		Meta: core.OperatorMetaDef{
-			Name: "encode URL",
+			Name:             "encode URL",
 			ShortDescription: "encodes a Slang map into the corresponding URL-encoded string",
-			Icon: "brackets",
-			Tags: []string{"http", "encoding"},
-			DocURL: "https://bitspark.de/slang/docs/operator/encode-url",
+			Icon:             "brackets",
+			Tags:             []string{"http", "encoding"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/encode-url",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/encoding_xlsx_read.go
+++ b/pkg/elem/encoding_xlsx_read.go
@@ -9,11 +9,11 @@ var encodingXLSXReadCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "69db81cf-2a24-4470-863f-ceffaeb8b246",
 		Meta: core.OperatorMetaDef{
-			Name: "read Excel",
+			Name:             "read Excel",
 			ShortDescription: "decodes Excel data into a stream of sheets, each being a 2d-stream of cells",
-			Icon: "file-excel",
-			Tags: []string{"http", "encoding"},
-			DocURL: "https://bitspark.de/slang/docs/operator/encode-url",
+			Icon:             "file-excel",
+			Tags:             []string{"http", "encoding"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/encode-url",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/files_append.go
+++ b/pkg/elem/files_append.go
@@ -1,20 +1,21 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"os"
 	"path/filepath"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var filesAppendCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "e49369c2-eac2-4dc7-9a6d-b635ae1654f9",
 		Meta: core.OperatorMetaDef{
-			Name: "append file",
+			Name:             "append file",
 			ShortDescription: "appends binary data to a file or creates it if non existent",
-			Icon: "file-plus",
-			Tags: []string{"file"},
-			DocURL: "https://bitspark.de/slang/docs/operator/append-file",
+			Icon:             "file-plus",
+			Tags:             []string{"file"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/append-file",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/files_read_lines.go
+++ b/pkg/elem/files_read_lines.go
@@ -2,20 +2,21 @@ package elem
 
 import (
 	"bufio"
-	"github.com/Bitspark/slang/pkg/core"
 	"os"
 	"path/filepath"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var filesReadLinesCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "6124cd6b-5c23-4e17-a714-458d0f8ac1a7",
 		Meta: core.OperatorMetaDef{
-			Name: "lines from file",
+			Name:             "lines from file",
 			ShortDescription: "reads the contents of a file line by line and emits them as stream",
-			Icon: "file",
-			Tags: []string{"file"},
-			DocURL: "https://bitspark.de/slang/docs/operator/lines-from-file",
+			Icon:             "file",
+			Tags:             []string{"file"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/lines-from-file",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/files_write.go
+++ b/pkg/elem/files_write.go
@@ -1,21 +1,22 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var filesWriteCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "9b61597d-cfbc-42d1-9620-210081244ba1",
 		Meta: core.OperatorMetaDef{
-			Name: "write file",
+			Name:             "write file",
 			ShortDescription: "creates or replaces a file and writes binary data to it",
-			Icon: "file-signature",
-			Tags: []string{"file"},
-			DocURL: "https://bitspark.de/slang/docs/operator/write-file",
+			Icon:             "file-signature",
+			Tags:             []string{"file"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/write-file",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/files_zip_pack.go
+++ b/pkg/elem/files_zip_pack.go
@@ -3,6 +3,7 @@ package elem
 import (
 	"archive/zip"
 	"bytes"
+
 	"github.com/Bitspark/slang/pkg/core"
 )
 
@@ -10,11 +11,11 @@ var filesZIPPackCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "dc5325bc-a816-47c8-8a8a-f741497459f7",
 		Meta: core.OperatorMetaDef{
-			Name: "pack ZIP",
+			Name:             "pack ZIP",
 			ShortDescription: "packs a stream of binary content into a zip archive",
-			Icon: "file-archive",
-			Tags: []string{"zip", "compression"},
-			DocURL: "https://bitspark.de/slang/docs/operator/pack-zip",
+			Icon:             "file-archive",
+			Tags:             []string{"zip", "compression"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/pack-zip",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/files_zip_unpack.go
+++ b/pkg/elem/files_zip_unpack.go
@@ -3,6 +3,7 @@ package elem
 import (
 	"archive/zip"
 	"bytes"
+
 	"github.com/Bitspark/slang/pkg/core"
 )
 
@@ -10,11 +11,11 @@ var filesZIPUnpackCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "04714d4a-1d5d-4b68-b614-524dd4662ef4",
 		Meta: core.OperatorMetaDef{
-			Name: "unpack ZIP",
+			Name:             "unpack ZIP",
 			ShortDescription: "unpacks a zip archive and emits a stream of files and their binary content",
-			Icon: "file-archive",
-			Tags: []string{"zip", "compression"},
-			DocURL: "https://bitspark.de/slang/docs/operator/unpack-zip",
+			Icon:             "file-archive",
+			Tags:             []string{"zip", "compression"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/unpack-zip",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/image_decode.go
+++ b/pkg/elem/image_decode.go
@@ -2,19 +2,20 @@ package elem
 
 import (
 	"bytes"
-	"github.com/Bitspark/slang/pkg/core"
 	"image"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var imageDecodeCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "4b082c52-9a99-472f-9277-f5ca9651dbfb",
 		Meta: core.OperatorMetaDef{
-			Name: "decode image",
+			Name:             "decode image",
 			ShortDescription: "reads an encoded image binary and emits its pixels as stream of rgb values",
-			Icon: "file-image",
-			Tags: []string{"image"},
-			DocURL: "https://bitspark.de/slang/docs/operator/decode-image",
+			Icon:             "file-image",
+			Tags:             []string{"image"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/decode-image",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/image_encode.go
+++ b/pkg/elem/image_encode.go
@@ -3,25 +3,26 @@ package elem
 import (
 	"bufio"
 	"bytes"
-	"github.com/Bitspark/go-funk"
-	"github.com/Bitspark/slang/pkg/core"
 	"image"
 	"image/color"
 	"image/jpeg"
 	_ "image/jpeg"
 	"image/png"
 	_ "image/png"
+
+	"github.com/Bitspark/go-funk"
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var imageEncodeCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "bd4475af-795b-4be8-9e57-9fec9444e028",
 		Meta: core.OperatorMetaDef{
-			Name: "encode image",
+			Name:             "encode image",
 			ShortDescription: "takes pixels as stream of rgb values and encodes it into an image binary",
-			Icon: "file-image",
-			Tags: []string{"image"},
-			DocURL: "https://bitspark.de/slang/docs/operator/encode-image",
+			Icon:             "file-image",
+			Tags:             []string{"image"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/encode-image",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/net_http_client.go
+++ b/pkg/elem/net_http_client.go
@@ -2,20 +2,21 @@ package elem
 
 import (
 	"bytes"
-	"github.com/Bitspark/slang/pkg/core"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var netHTTPClientCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "f7f5907d-758b-4892-8a3e-ae86b877b869",
 		Meta: core.OperatorMetaDef{
-			Name: "HTTP client",
+			Name:             "HTTP client",
 			ShortDescription: "sends an HTTP request",
-			Icon: "browser",
-			Tags: []string{"network", "http"},
-			DocURL: "https://bitspark.de/slang/docs/operator/http-client",
+			Icon:             "browser",
+			Tags:             []string{"network", "http"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/http-client",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/net_http_server.go
+++ b/pkg/elem/net_http_server.go
@@ -10,8 +10,6 @@ import (
 )
 
 type requestHandler struct {
-	hOut *core.Port
-	hIn  *core.Port
 	sync *core.Synchronizer
 }
 

--- a/pkg/elem/net_mqtt_publish.go
+++ b/pkg/elem/net_mqtt_publish.go
@@ -2,18 +2,18 @@ package elem
 
 import (
 	"github.com/Bitspark/slang/pkg/core"
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
 var netMQTTPublishCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "c6b5bef6-e93e-4bc1-8ded-49c90919f39d",
 		Meta: core.OperatorMetaDef{
-			Name: "MQTT publish",
+			Name:             "MQTT publish",
 			ShortDescription: "publishes an MQTT message at a given topic",
-			Icon: "chart-network",
-			Tags: []string{"network", "mqtt"},
-			DocURL: "https://bitspark.de/slang/docs/operator/mqtt-publish",
+			Icon:             "chart-network",
+			Tags:             []string{"network", "mqtt"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/mqtt-publish",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/net_mqtt_subscribe.go
+++ b/pkg/elem/net_mqtt_subscribe.go
@@ -2,18 +2,18 @@ package elem
 
 import (
 	"github.com/Bitspark/slang/pkg/core"
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
 var netMQTTSubscribeCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "fd51e295-3483-4558-9b26-8c16d579c4ef",
 		Meta: core.OperatorMetaDef{
-			Name: "MQTT subscribe",
+			Name:             "MQTT subscribe",
 			ShortDescription: "subscribes at a given topic, behaves like an MQTT client",
-			Icon: "chart-network",
-			Tags: []string{"network", "mqtt"},
-			DocURL: "https://bitspark.de/slang/docs/operator/mqtt-subscribe",
+			Icon:             "chart-network",
+			Tags:             []string{"network", "mqtt"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/mqtt-subscribe",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/net_send_email.go
+++ b/pkg/elem/net_send_email.go
@@ -3,21 +3,22 @@ package elem
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/Bitspark/slang/pkg/core"
 	"net"
 	"net/mail"
 	"net/smtp"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var netSendEmailCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "741b8a21-0b6d-40e5-a281-b179a49e9030",
 		Meta: core.OperatorMetaDef{
-			Name: "send email",
+			Name:             "send email",
 			ShortDescription: "sends an email",
-			Icon: "envelope",
-			Tags: []string{"network", "smtp", "email"},
-			DocURL: "https://bitspark.de/slang/docs/operator/send-email",
+			Icon:             "envelope",
+			Tags:             []string{"network", "smtp", "email"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/send-email",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/shell_execute.go
+++ b/pkg/elem/shell_execute.go
@@ -1,8 +1,9 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"os/exec"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var shellExecuteCfg = &builtinConfig{

--- a/pkg/elem/shell_execute.go
+++ b/pkg/elem/shell_execute.go
@@ -118,7 +118,7 @@ var shellExecuteCfg = &builtinConfig{
 			stderr, _ := c.StderrPipe()
 			stdin, _ := c.StdinPipe()
 
-			err := c.Start()
+			c.Start()
 			// Redirect stdout to out port
 			go func() {
 				user.Out().Map("stdout").PushBOS()
@@ -169,7 +169,7 @@ var shellExecuteCfg = &builtinConfig{
 					out.Map("stdin").Stream().Push(input)
 				}
 			}()
-			err = c.Wait()
+			err := c.Wait()
 			if err != nil {
 				out.Map("code").Push(err.Error())
 			} else {

--- a/pkg/elem/stream_concatenate.go
+++ b/pkg/elem/stream_concatenate.go
@@ -8,11 +8,11 @@ var streamConcatenateCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "fb174c53-80bd-4e29-955a-aafe33ebfb30",
 		Meta: core.OperatorMetaDef{
-			Name: "concatenate",
+			Name:             "concatenate",
 			ShortDescription: "concatenates two streams",
-			Icon: "layer-plus",
-			Tags: []string{"stream"},
-			DocURL: "https://bitspark.de/slang/docs/operator/concatenate",
+			Icon:             "layer-plus",
+			Tags:             []string{"stream"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/concatenate",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {
@@ -22,7 +22,7 @@ var streamConcatenateCfg = &builtinConfig{
 						"stream_{streams}": {
 							Type: "stream",
 							Stream: &core.TypeDef{
-								Type: "generic",
+								Type:    "generic",
 								Generic: "itemType",
 							},
 						},
@@ -31,7 +31,7 @@ var streamConcatenateCfg = &builtinConfig{
 				Out: core.TypeDef{
 					Type: "stream",
 					Stream: &core.TypeDef{
-						Type: "generic",
+						Type:    "generic",
 						Generic: "itemType",
 					},
 				},
@@ -52,7 +52,7 @@ var streamConcatenateCfg = &builtinConfig{
 		indexesProp := op.Property("streams").([]interface{})
 		streams := make([]*core.Port, len(indexesProp))
 		for i, idxProp := range indexesProp {
-			streams[i] = in.Map("stream_"+idxProp.(string))
+			streams[i] = in.Map("stream_" + idxProp.(string))
 		}
 		for !op.CheckStop() {
 			item := streams[0].Stream().Pull()

--- a/pkg/elem/stream_distinct.go
+++ b/pkg/elem/stream_distinct.go
@@ -1,19 +1,20 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"strconv"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var streamDistinctCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "d8914bae-2878-46f3-b468-9e7faea7a463",
 		Meta: core.OperatorMetaDef{
-			Name: "distinct values",
+			Name:             "distinct values",
 			ShortDescription: "takes a streams and emits distinct items",
-			Icon: "shapes",
-			Tags: []string{"stream"},
-			DocURL: "https://bitspark.de/slang/docs/operator/distinct",
+			Icon:             "shapes",
+			Tags:             []string{"stream"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/distinct",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/stream_serialize.go
+++ b/pkg/elem/stream_serialize.go
@@ -1,20 +1,21 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
-	"strings"
 	"strconv"
+	"strings"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var streamSerializeCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "13257172-b05d-497c-be23-da7c86577c1e",
 		Meta: core.OperatorMetaDef{
-			Name: "serialize",
+			Name:             "serialize",
 			ShortDescription: "takes a map of items and serializes them into a stream",
-			Icon: "ellipsis-h",
-			Tags: []string{"stream", "convert"},
-			DocURL: "https://bitspark.de/slang/docs/operator/serialize",
+			Icon:             "ellipsis-h",
+			Tags:             []string{"stream", "convert"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/serialize",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {
@@ -69,7 +70,7 @@ var streamSerializeCfg = &builtinConfig{
 				}
 			}
 
-			stream := make([]interface{}, maxIndex + 1)
+			stream := make([]interface{}, maxIndex+1)
 			for k, v := range im {
 				index, _ := strconv.Atoi(k[3:])
 				stream[index] = v

--- a/pkg/elem/stream_slice.go
+++ b/pkg/elem/stream_slice.go
@@ -8,11 +8,11 @@ var streamSliceCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "2471a7aa-c5b9-4392-b23f-d0c7bcdb3f39",
 		Meta: core.OperatorMetaDef{
-			Name: "slice",
+			Name:             "slice",
 			ShortDescription: "emits a sub-stream of another stream",
-			Icon: "cut",
-			Tags: []string{"stream"},
-			DocURL: "https://bitspark.de/slang/docs/operator/slice",
+			Icon:             "cut",
+			Tags:             []string{"stream"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/slice",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {
@@ -22,19 +22,19 @@ var streamSliceCfg = &builtinConfig{
 						"offset": {
 							Type: "stream",
 							Stream: &core.TypeDef{
-								Type:    "number",
+								Type: "number",
 							},
 						},
 						"length": {
 							Type: "stream",
 							Stream: &core.TypeDef{
-								Type:    "number",
+								Type: "number",
 							},
 						},
 						"step": {
 							Type: "stream",
 							Stream: &core.TypeDef{
-								Type:    "number",
+								Type: "number",
 							},
 						},
 						"stream": {
@@ -79,7 +79,7 @@ var streamSliceCfg = &builtinConfig{
 			step := int(im["step"].(float64))
 
 			until := len(stream)
-			if until > offset + length {
+			if until > offset+length {
 				until = offset + length
 			}
 

--- a/pkg/elem/stream_stream_to_map.go
+++ b/pkg/elem/stream_stream_to_map.go
@@ -8,11 +8,11 @@ var streamStreamToMapCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "42d0f961-4ce0-4a20-b1b0-3da46396ae66",
 		Meta: core.OperatorMetaDef{
-			Name: "stream to map",
+			Name:             "stream to map",
 			ShortDescription: "takes a map and emits a stream of key-value pairs",
-			Icon: "cubes",
-			Tags: []string{"stream", "convert"},
-			DocURL: "https://bitspark.de/slang/docs/operator/map-to-stream",
+			Icon:             "cubes",
+			Tags:             []string{"stream", "convert"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/map-to-stream",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/stream_transform.go
+++ b/pkg/elem/stream_transform.go
@@ -8,11 +8,11 @@ var streamTransformCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "dce082cb-7272-4e85-b4fa-740778e8ba8d",
 		Meta: core.OperatorMetaDef{
-			Name: "transform stream",
+			Name:             "transform stream",
 			ShortDescription: "transforms a stream by iterating it using an iterator delegate",
-			Icon: "code-commit",
-			Tags: []string{"stream"},
-			DocURL: "https://bitspark.de/slang/docs/operator/map-to-stream",
+			Icon:             "code-commit",
+			Tags:             []string{"stream"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/map-to-stream",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/stream_window_collect.go
+++ b/pkg/elem/stream_window_collect.go
@@ -1,8 +1,9 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"sync"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 type windowStore struct {
@@ -30,11 +31,11 @@ var streamWindowCollectCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "14f5de1a-5e38-4f9c-a625-eff7a572078c",
 		Meta: core.OperatorMetaDef{
-			Name: "collect window",
+			Name:             "collect window",
 			ShortDescription: "collects items from a stream until released",
-			Icon: "window",
-			Tags: []string{"stream", "window"},
-			DocURL: "https://bitspark.de/slang/docs/operator/window-collect",
+			Icon:             "window",
+			Tags:             []string{"stream", "window"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/window-collect",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {
@@ -47,8 +48,7 @@ var streamWindowCollectCfg = &builtinConfig{
 				},
 			},
 		},
-		DelegateDefs: map[string]*core.DelegateDef{
-		},
+		DelegateDefs: map[string]*core.DelegateDef{},
 		PropertyDefs: map[string]*core.TypeDef{
 			"store": {
 				Type: "string",

--- a/pkg/elem/stream_window_release.go
+++ b/pkg/elem/stream_window_release.go
@@ -8,11 +8,11 @@ var streamWindowReleaseCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "47b3f097-2043-42c6-aad5-0cfdb9004aef",
 		Meta: core.OperatorMetaDef{
-			Name: "release window",
+			Name:             "release window",
 			ShortDescription: "releases windows of items collected before",
-			Icon: "window-maximize",
-			Tags: []string{"stream", "window"},
-			DocURL: "https://bitspark.de/slang/docs/operator/window-release",
+			Icon:             "window-maximize",
+			Tags:             []string{"stream", "window"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/window-release",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {
@@ -28,8 +28,7 @@ var streamWindowReleaseCfg = &builtinConfig{
 				},
 			},
 		},
-		DelegateDefs: map[string]*core.DelegateDef{
-		},
+		DelegateDefs: map[string]*core.DelegateDef{},
 		PropertyDefs: map[string]*core.TypeDef{
 			"store": {
 				Type: "string",

--- a/pkg/elem/string_beginswith.go
+++ b/pkg/elem/string_beginswith.go
@@ -10,11 +10,11 @@ var stringBeginswithCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "9f274995-2726-4513-ac7c-f15ac7b68720",
 		Meta: core.OperatorMetaDef{
-			Name: "begins with",
+			Name:             "begins with",
 			ShortDescription: "tells if a string begins with another string",
-			Icon: "hand-point-left",
-			Tags: []string{"string"},
-			DocURL: "https://bitspark.de/slang/docs/operator/begins-with",
+			Icon:             "hand-point-left",
+			Tags:             []string{"string"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/begins-with",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/string_contains.go
+++ b/pkg/elem/string_contains.go
@@ -10,11 +10,11 @@ var stringContainsCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "8a01dfe3-5dcf-4f40-9e54-f5b168148d2a",
 		Meta: core.OperatorMetaDef{
-			Name: "contains",
+			Name:             "contains",
 			ShortDescription: "tells if a string contains another string",
-			Icon: "search",
-			Tags: []string{"string"},
-			DocURL: "https://bitspark.de/slang/docs/operator/contains",
+			Icon:             "search",
+			Tags:             []string{"string"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/contains",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/string_endswith.go
+++ b/pkg/elem/string_endswith.go
@@ -10,11 +10,11 @@ var stringEndswithCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "db8b1677-baaf-4072-8047-0359cd68be9e",
 		Meta: core.OperatorMetaDef{
-			Name: "ends with",
+			Name:             "ends with",
 			ShortDescription: "tells if a string ends with another string",
-			Icon: "hand-point-right",
-			Tags: []string{"string"},
-			DocURL: "https://bitspark.de/slang/docs/operator/ends-with",
+			Icon:             "hand-point-right",
+			Tags:             []string{"string"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/ends-with",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/string_format.go
+++ b/pkg/elem/string_format.go
@@ -1,19 +1,20 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"fmt"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var stringFormatCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "21dbddf2-2d07-494e-8950-3ac0224a3ff5",
 		Meta: core.OperatorMetaDef{
-			Name: "format",
+			Name:             "format",
 			ShortDescription: "places values formatted in a C-like manner inside a string",
-			Icon: "edit",
-			Tags: []string{"string"},
-			DocURL: "https://bitspark.de/slang/docs/operator/format",
+			Icon:             "edit",
+			Tags:             []string{"string"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/format",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/string_split.go
+++ b/pkg/elem/string_split.go
@@ -1,19 +1,20 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"strings"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var stringSplitCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "c02bc7ad-65e5-4a43-a2a3-7d86b109915d",
 		Meta: core.OperatorMetaDef{
-			Name: "split string",
+			Name:             "split string",
 			ShortDescription: "splits a string at a given separator and emits its pieces as stream",
-			Icon: "cut",
-			Tags: []string{"string"},
-			DocURL: "https://bitspark.de/slang/docs/operator/split-string",
+			Icon:             "cut",
+			Tags:             []string{"string"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/split-string",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/time_crontab.go
+++ b/pkg/elem/time_crontab.go
@@ -9,11 +9,11 @@ var timeCrontabCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "60b849fd-ca5a-4206-8312-996e4e3f6c31",
 		Meta: core.OperatorMetaDef{
-			Name: "crontab",
+			Name:             "crontab",
 			ShortDescription: "takes a UNIX crontab string, sends triggers to its handler delegate accordingly",
-			Icon: "calendar-alt",
-			Tags: []string{"time"},
-			DocURL: "https://bitspark.de/slang/docs/operator/crontab",
+			Icon:             "calendar-alt",
+			Tags:             []string{"time"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/crontab",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {
@@ -23,7 +23,7 @@ var timeCrontabCfg = &builtinConfig{
 				Out: core.TypeDef{
 					Type: "stream",
 					Stream: &core.TypeDef{
-						Type: "generic",
+						Type:    "generic",
 						Generic: "itemType",
 					},
 				},
@@ -35,7 +35,7 @@ var timeCrontabCfg = &builtinConfig{
 					Type: "trigger",
 				},
 				In: core.TypeDef{
-					Type: "generic",
+					Type:    "generic",
 					Generic: "itemType",
 				},
 			},

--- a/pkg/elem/time_date.go
+++ b/pkg/elem/time_date.go
@@ -1,8 +1,9 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"time"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 func parseDate(dateStr string) (time.Time, error) {
@@ -24,11 +25,11 @@ var timeParseDateCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "2a9da2d5-2684-4d2f-8a37-9560d0f2de29",
 		Meta: core.OperatorMetaDef{
-			Name: "to date",
+			Name:             "to date",
 			ShortDescription: "takes a string containing date and time and emits its parsed values",
-			Icon: "calendar-week",
-			Tags: []string{"time"},
-			DocURL: "https://bitspark.de/slang/docs/operator/to-date",
+			Icon:             "calendar-week",
+			Tags:             []string{"time"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/to-date",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/time_date_now.go
+++ b/pkg/elem/time_date_now.go
@@ -1,19 +1,20 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"time"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var timeDateNowCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "808c7846-db9f-43ee-989b-37a08ce7e70d",
 		Meta: core.OperatorMetaDef{
-			Name: "now",
+			Name:             "now",
 			ShortDescription: "emits the current date and time",
-			Icon: "clock",
-			Tags: []string{"time"},
-			DocURL: "https://bitspark.de/slang/docs/operator/now",
+			Icon:             "clock",
+			Tags:             []string{"time"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/now",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/pkg/elem/time_unix.go
+++ b/pkg/elem/time_unix.go
@@ -1,19 +1,20 @@
 package elem
 
 import (
-	"github.com/Bitspark/slang/pkg/core"
 	"time"
+
+	"github.com/Bitspark/slang/pkg/core"
 )
 
 var timeUNIXMillisCfg = &builtinConfig{
 	opDef: core.OperatorDef{
 		Id: "d58b458e-8b3a-49f3-a6e9-45e737354937",
 		Meta: core.OperatorMetaDef{
-			Name: "UNIX milliseconds",
+			Name:             "UNIX milliseconds",
 			ShortDescription: "emits the current UNIX timestamp in milliseconds",
-			Icon: "stamp",
-			Tags: []string{"time"},
-			DocURL: "https://bitspark.de/slang/docs/operator/unix-milliseconds",
+			Icon:             "stamp",
+			Tags:             []string{"time"},
+			DocURL:           "https://bitspark.de/slang/docs/operator/unix-milliseconds",
 		},
 		ServiceDefs: map[string]*core.ServiceDef{
 			core.MAIN_SERVICE: {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -19,20 +18,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func parseJSON(str string) interface{} {
-	var obj interface{}
-	json.Unmarshal([]byte(str), &obj)
-	return obj
-}
-
 func validateJSONOperatorDef(jsonDef string) (core.OperatorDef, error) {
 	def, _ := core.ParseJSONOperatorDef(jsonDef)
-	return def, def.Validate()
-}
-
-func validateJSONInstanceDef(jsonDef string) (core.InstanceDef, error) {
-	def := core.InstanceDef{}
-	json.Unmarshal([]byte(jsonDef), &def)
 	return def, def.Validate()
 }
 


### PR DESCRIPTION
This PR introduces linting into the CI it uses https://github.com/golangci/golangci-lint to selectivly enable or disable linters. 

Currently enabled linters are:
* `deadcode` Finds unused code
* `govet` (vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
* `unconvert`: Remove unnecessary type conversions
* `staticcheck`: Staticcheck is a go vet on steroids, applying a ton of static analysis checks
* `gofmt`: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
* `varcheck`: Finds unused global variables and constants
* `unused`: Checks Go code for unused constants, variables, functions and types
* `unparam`: Reports unused function parameters
* `scopelint`: Scopelint checks for unpinned variables in go programs
* `structcheck`: Finds an unused struct fields

There are a lot of other linters available see https://github.com/golangci/golangci-lint#supported-linters for a complet list