### PR TITLE
Add endpoint that exposes the running instances

### DIFF
--- a/pkg/daemon/proxy.go
+++ b/pkg/daemon/proxy.go
@@ -29,13 +29,7 @@ func proxyRequestToOperator(w http.ResponseWriter, r *http.Request) {
 		newPath = path[sp:]
 	}
 
-	handleID, err := strconv.ParseInt(handle, 16, 64)
-	if err != nil {
-		w.WriteHeader(400)
-		return
-	}
-
-	operator, ok := runningInstances[handleID]
+	operator, ok := runningInstances[handle]
 	if !ok {
 		w.WriteHeader(404)
 		return

--- a/pkg/daemon/proxy.go
+++ b/pkg/daemon/proxy.go
@@ -41,7 +41,7 @@ func proxyRequestToOperator(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newPort := operator.port
+	newPort := operator.Port
 	newURL := url.URL{}
 	newURL.Scheme = "http"
 	newURL.Host = "localhost:" + strconv.Itoa(newPort)

--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -14,13 +14,13 @@ import (
 	"github.com/google/uuid"
 )
 
-type runInstructionJSON struct {
+type RunInstructionJSON struct {
 	Id     string          `json:"id"`
 	Props  core.Properties `json:"props"`
 	Gens   core.Generics   `json:"gens"`
 	Stream bool            `json:"stream"`
 }
-type outJSON struct {
+type InstanceStateJSON struct {
 	URL    string `json:"url,omitempty"`
 	Handle string `json:"handle,omitempty"`
 	Status string `json:"status"`
@@ -59,13 +59,13 @@ var RunnerService = &Service{map[string]*Endpoint{
 		hub := GetHub(r)
 		st := GetStorage(r)
 		if r.Method == "POST" {
-			var data outJSON
+			var data InstanceStateJSON
 
 			decoder := json.NewDecoder(r.Body)
-			var ri runInstructionJSON
+			var ri RunInstructionJSON
 			err := decoder.Decode(&ri)
 			if err != nil {
-				data = outJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
+				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
 				writeJSON(w, &data)
 				return
 			}
@@ -86,7 +86,7 @@ var RunnerService = &Service{map[string]*Endpoint{
 			opId, err := uuid.Parse(ri.Id)
 
 			if err != nil {
-				data = outJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
+				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
 				writeJSON(w, &data)
 				return
 			}
@@ -99,7 +99,7 @@ var RunnerService = &Service{map[string]*Endpoint{
 			}
 
 			if err != nil {
-				data = outJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
+				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
 				writeJSON(w, &data)
 				return
 			}
@@ -108,7 +108,7 @@ var RunnerService = &Service{map[string]*Endpoint{
 			httpDefId, _ := uuid.Parse(httpDef.Id)
 			op, err := api.BuildAndCompile(httpDefId, nil, nil, st)
 			if err != nil {
-				data = outJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
+				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
 				writeJSON(w, &data)
 				return
 			}

--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -15,7 +15,7 @@ import (
 )
 
 type RunInstructionJSON struct {
-	Id     string          `json:"id"`
+	Id     uuid.UUID       `json:"id"`
 	Props  core.Properties `json:"props"`
 	Gens   core.Generics   `json:"gens"`
 	Stream bool            `json:"stream"`
@@ -29,7 +29,8 @@ type InstanceStateJSON struct {
 
 type runningInstance struct {
 	Port int            `json:"port"`
-	Op   *core.Operator `json:"omit"`
+	OpId uuid.UUID      `json:"id"`
+	Op   *core.Operator `json:"Op"`
 }
 
 var runningInstances = make(map[string]runningInstance)
@@ -94,7 +95,7 @@ var RunnerService = &Service{map[string]*Endpoint{
 				}
 			}
 
-			opId, err := uuid.Parse(ri.Id)
+			opId := ri.Id
 
 			if err != nil {
 				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}

--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -14,13 +14,13 @@ import (
 	"github.com/google/uuid"
 )
 
-type RunInstructionJSON struct {
+type RunInstruction struct {
 	Id     uuid.UUID       `json:"id"`
 	Props  core.Properties `json:"props"`
 	Gens   core.Generics   `json:"gens"`
 	Stream bool            `json:"stream"`
 }
-type InstanceStateJSON struct {
+type InstanceState struct {
 	URL    string `json:"url,omitempty"`
 	Handle string `json:"handle,omitempty"`
 	Status string `json:"status"`
@@ -71,13 +71,13 @@ var RunnerService = &Service{map[string]*Endpoint{
 		hub := GetHub(r)
 		st := GetStorage(r)
 		if r.Method == "POST" {
-			var data InstanceStateJSON
+			var data InstanceState
 
 			decoder := json.NewDecoder(r.Body)
-			var ri RunInstructionJSON
+			var ri RunInstruction
 			err := decoder.Decode(&ri)
 			if err != nil {
-				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
+				data = InstanceState{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
 				writeJSON(w, &data)
 				return
 			}
@@ -98,7 +98,7 @@ var RunnerService = &Service{map[string]*Endpoint{
 			opId := ri.Id
 
 			if err != nil {
-				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
+				data = InstanceState{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
 				writeJSON(w, &data)
 				return
 			}
@@ -111,7 +111,7 @@ var RunnerService = &Service{map[string]*Endpoint{
 			}
 
 			if err != nil {
-				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
+				data = InstanceState{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
 				writeJSON(w, &data)
 				return
 			}
@@ -120,7 +120,7 @@ var RunnerService = &Service{map[string]*Endpoint{
 			httpDefId, _ := uuid.Parse(httpDef.Id)
 			op, err := api.BuildAndCompile(httpDefId, nil, nil, st)
 			if err != nil {
-				data = InstanceStateJSON{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
+				data = InstanceState{Status: "error", Error: &Error{Msg: err.Error(), Code: "E000X"}}
 				writeJSON(w, &data)
 				return
 			}

--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -55,10 +55,6 @@ func (l *httpDefLoader) Load(opId uuid.UUID) (*core.OperatorDef, error) {
 }
 
 var RunnerService = &Service{map[string]*Endpoint{
-	"/alive": {func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
-		}
-	}},
 	"/": {func(w http.ResponseWriter, r *http.Request) {
 		hub := GetHub(r)
 		st := GetStorage(r)

--- a/pkg/daemon/runner_service.go
+++ b/pkg/daemon/runner_service.go
@@ -14,6 +14,19 @@ import (
 	"github.com/google/uuid"
 )
 
+type runInstructionJSON struct {
+	Id     string          `json:"id"`
+	Props  core.Properties `json:"props"`
+	Gens   core.Generics   `json:"gens"`
+	Stream bool            `json:"stream"`
+}
+type outJSON struct {
+	URL    string `json:"url,omitempty"`
+	Handle string `json:"handle,omitempty"`
+	Status string `json:"status"`
+	Error  *Error `json:"error,omitempty"`
+}
+
 var runningInstances = make(map[int64]struct {
 	port int
 	op   *core.Operator
@@ -42,23 +55,13 @@ func (l *httpDefLoader) Load(opId uuid.UUID) (*core.OperatorDef, error) {
 }
 
 var RunnerService = &Service{map[string]*Endpoint{
+	"/alive": {func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+		}
+	}},
 	"/": {func(w http.ResponseWriter, r *http.Request) {
 		st := GetStorage(r)
 		if r.Method == "POST" {
-			type runInstructionJSON struct {
-				Id     string          `json:"id"`
-				Props  core.Properties `json:"props"`
-				Gens   core.Generics   `json:"gens"`
-				Stream bool            `json:"stream"`
-			}
-
-			type outJSON struct {
-				URL    string `json:"url,omitempty"`
-				Handle string `json:"handle,omitempty"`
-				Status string `json:"status"`
-				Error  *Error `json:"error,omitempty"`
-			}
-
 			var data outJSON
 
 			decoder := json.NewDecoder(r.Body)

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -248,6 +248,7 @@ func (s *Server) mountWebServices() {
 	s.AddService("/operator", DefinitionService)
 	s.AddService("/run", RunnerService)
 	s.AddService("/share", SharingService)
+	s.AddService("/instances", InstanceService)
 	s.AddOperatorProxy("/instance")
 	s.AddWebsocket("/ws")
 }

--- a/pkg/daemon/server_test.go
+++ b/pkg/daemon/server_test.go
@@ -1,11 +1,15 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Bitspark/slang/pkg/core"
 	"github.com/Bitspark/slang/pkg/env"
 	"github.com/Bitspark/slang/pkg/storage"
 	"github.com/Bitspark/slang/tests"
@@ -18,6 +22,19 @@ func getTestServer() *Server {
 	storage := storage.NewStorage().AddBackend(backend)
 	ctx := SetStorage(context.Background(), storage)
 	return NewServer(&ctx, env)
+}
+func TestServer_operator_starting(t *testing.T) {
+	server := getTestServer()
+	data := runInstructionJSON{Id: "37ccdc28-67b0-4bb1-8591-4e0e813e3ec1",
+		Stream: false,
+		Props:  core.Properties{}, Gens: core.Generics{}}
+	body, _ := json.Marshal(&data)
+	request, _ := http.NewRequest("POST", "/run/", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, request)
+	a := response.Body.String()
+	fmt.Println(a)
+	assert.Equal(t, 200, response.Code)
 }
 
 func TestServer_operator(t *testing.T) {

--- a/pkg/daemon/server_test.go
+++ b/pkg/daemon/server_test.go
@@ -1,0 +1,29 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Bitspark/slang/pkg/env"
+	"github.com/Bitspark/slang/pkg/storage"
+	"github.com/Bitspark/slang/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestServer() *Server {
+	backend := tests.NewTestLoader("./")
+	env := env.New("localhost", 8000)
+	storage := storage.NewStorage().AddBackend(backend)
+	ctx := SetStorage(context.Background(), storage)
+	return NewServer(&ctx, env)
+}
+
+func TestServer_operator(t *testing.T) {
+	server := getTestServer()
+	request, _ := http.NewRequest("GET", "/operator/", nil)
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, request)
+	assert.Equal(t, 200, response.Code)
+}

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -43,7 +43,8 @@ func startOperator(t *testing.T, s *daemon.Server, ri daemon.RunInstructionJSON)
 }
 func TestServer_operator_starting(t *testing.T) {
 	server := getTestServer()
-	data := daemon.RunInstructionJSON{Id: "8b62495a-e482-4a3e-8020-0ab8a350ad2d",
+	id, _ := uuid.Parse("8b62495a-e482-4a3e-8020-0ab8a350ad2d")
+	data := daemon.RunInstructionJSON{Id: id,
 		Stream: false,
 		Props:  core.Properties{"value": "slang"},
 		Gens: core.Generics{
@@ -61,7 +62,9 @@ func TestServer_operator_starting(t *testing.T) {
 
 func TestServer_operator(t *testing.T) {
 	server := getTestServer()
-	data := daemon.RunInstructionJSON{Id: "8b62495a-e482-4a3e-8020-0ab8a350ad2d",
+	id := "8b62495a-e482-4a3e-8020-0ab8a350ad2d"
+	uuid, _ := uuid.Parse("8b62495a-e482-4a3e-8020-0ab8a350ad2d")
+	data := daemon.RunInstructionJSON{Id: uuid,
 		Stream: false,
 		Props:  core.Properties{"value": "slang"},
 		Gens: core.Generics{
@@ -75,4 +78,5 @@ func TestServer_operator(t *testing.T) {
 	response := httptest.NewRecorder()
 	server.Handler().ServeHTTP(response, request)
 	assert.Equal(t, 200, response.Code)
+	assert.Contains(t, response.Body.String(), id)
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -26,8 +26,8 @@ func getTestServer() *daemon.Server {
 	return daemon.NewServer(&ctx, env)
 }
 
-func startOperator(t *testing.T, s *daemon.Server, ri daemon.RunInstructionJSON) daemon.InstanceStateJSON {
-	var out daemon.InstanceStateJSON
+func startOperator(t *testing.T, s *daemon.Server, ri daemon.RunInstructionJSON) daemon.InstanceState {
+	var out daemon.InstanceState
 
 	body, _ := json.Marshal(&ri)
 	request, _ := http.NewRequest("POST", "/run/", bytes.NewReader(body))

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -26,7 +26,7 @@ func getTestServer() *daemon.Server {
 	return daemon.NewServer(&ctx, env)
 }
 
-func startOperator(t *testing.T, s *daemon.Server, ri daemon.RunInstructionJSON) daemon.InstanceState {
+func startOperator(t *testing.T, s *daemon.Server, ri daemon.RunInstruction) daemon.InstanceState {
 	var out daemon.InstanceState
 
 	body, _ := json.Marshal(&ri)
@@ -44,7 +44,7 @@ func startOperator(t *testing.T, s *daemon.Server, ri daemon.RunInstructionJSON)
 func TestServer_operator_starting(t *testing.T) {
 	server := getTestServer()
 	id, _ := uuid.Parse("8b62495a-e482-4a3e-8020-0ab8a350ad2d")
-	data := daemon.RunInstructionJSON{Id: id,
+	data := daemon.RunInstruction{Id: id,
 		Stream: false,
 		Props:  core.Properties{"value": "slang"},
 		Gens: core.Generics{
@@ -64,7 +64,7 @@ func TestServer_operator(t *testing.T) {
 	server := getTestServer()
 	id := "8b62495a-e482-4a3e-8020-0ab8a350ad2d"
 	uuid, _ := uuid.Parse("8b62495a-e482-4a3e-8020-0ab8a350ad2d")
-	data := daemon.RunInstructionJSON{Id: uuid,
+	data := daemon.RunInstruction{Id: uuid,
 		Stream: false,
 		Props:  core.Properties{"value": "slang"},
 		Gens: core.Generics{

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -24,8 +23,23 @@ func getTestServer() *daemon.Server {
 	storage := storage.NewStorage().AddBackend(backend)
 	ctx := daemon.SetStorage(context.Background(), storage)
 	backend.Reload()
-	fmt.Println(backend.List())
 	return daemon.NewServer(&ctx, env)
+}
+
+func startOperator(t *testing.T, s *daemon.Server, ri daemon.RunInstructionJSON) daemon.InstanceStateJSON {
+	var out daemon.InstanceStateJSON
+
+	body, _ := json.Marshal(&ri)
+	request, _ := http.NewRequest("POST", "/run/", bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	s.Handler().ServeHTTP(response, request)
+
+	decoder := json.NewDecoder(response.Body)
+	decoder.Decode(&out)
+
+	assert.Equal(t, 200, response.Code)
+	assert.Equal(t, "success", out.Status)
+	return out
 }
 func TestServer_operator_starting(t *testing.T) {
 	server := getTestServer()
@@ -38,25 +52,26 @@ func TestServer_operator_starting(t *testing.T) {
 			},
 		},
 	}
-	body, _ := json.Marshal(&data)
-	request, _ := http.NewRequest("POST", "/run/", bytes.NewReader(body))
+	instance := startOperator(t, server, data)
+	request, _ := http.NewRequest("POST", strings.Join([]string{"/instance/", instance.Handle}, ""), bytes.NewReader([]byte{}))
 	response := httptest.NewRecorder()
-	server.Handler().ServeHTTP(response, request)
-	decoder := json.NewDecoder(response.Body)
-	var out daemon.InstanceStateJSON
-	decoder.Decode(&out)
-	assert.Equal(t, 200, response.Code)
-	assert.Equal(t, "success", out.Status)
-
-	request, _ = http.NewRequest("POST", strings.Join([]string{"/instance/", out.Handle}, ""), bytes.NewReader([]byte{}))
-	response = httptest.NewRecorder()
 	server.Handler().ServeHTTP(response, request)
 	assert.Equal(t, "\"slang\"", response.Body.String())
 }
 
 func TestServer_operator(t *testing.T) {
 	server := getTestServer()
-	request, _ := http.NewRequest("GET", "/operator/", nil)
+	data := daemon.RunInstructionJSON{Id: "8b62495a-e482-4a3e-8020-0ab8a350ad2d",
+		Stream: false,
+		Props:  core.Properties{"value": "slang"},
+		Gens: core.Generics{
+			"valueType": {
+				Type: "string",
+			},
+		},
+	}
+	startOperator(t, server, data)
+	request, _ := http.NewRequest("GET", "/instances/", nil)
 	response := httptest.NewRecorder()
 	server.Handler().ServeHTTP(response, request)
 	assert.Equal(t, 200, response.Code)

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/Bitspark/slang/pkg/daemon"
 	"github.com/Bitspark/slang/pkg/env"
 	"github.com/Bitspark/slang/pkg/storage"
-	"github.com/Bitspark/slang/tests"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func getTestServer() *daemon.Server {
-	backend := tests.NewTestLoader("./")
+	backend := NewTestLoader("./")
 	env := env.New("localhost", 8000)
 	storage := storage.NewStorage().AddBackend(backend)
 	ctx := daemon.SetStorage(context.Background(), storage)

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -1,4 +1,4 @@
-package daemon
+package tests
 
 import (
 	"bytes"
@@ -11,24 +11,25 @@ import (
 	"testing"
 
 	"github.com/Bitspark/slang/pkg/core"
+	"github.com/Bitspark/slang/pkg/daemon"
 	"github.com/Bitspark/slang/pkg/env"
 	"github.com/Bitspark/slang/pkg/storage"
 	"github.com/Bitspark/slang/tests"
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestServer() *Server {
+func getTestServer() *daemon.Server {
 	backend := tests.NewTestLoader("./")
 	env := env.New("localhost", 8000)
 	storage := storage.NewStorage().AddBackend(backend)
-	ctx := SetStorage(context.Background(), storage)
+	ctx := daemon.SetStorage(context.Background(), storage)
 	backend.Reload()
 	fmt.Println(backend.List())
-	return NewServer(&ctx, env)
+	return daemon.NewServer(&ctx, env)
 }
 func TestServer_operator_starting(t *testing.T) {
 	server := getTestServer()
-	data := runInstructionJSON{Id: "8b62495a-e482-4a3e-8020-0ab8a350ad2d",
+	data := daemon.RunInstructionJSON{Id: "8b62495a-e482-4a3e-8020-0ab8a350ad2d",
 		Stream: false,
 		Props:  core.Properties{"value": "slang"},
 		Gens: core.Generics{
@@ -42,7 +43,7 @@ func TestServer_operator_starting(t *testing.T) {
 	response := httptest.NewRecorder()
 	server.Handler().ServeHTTP(response, request)
 	decoder := json.NewDecoder(response.Body)
-	var out outJSON
+	var out daemon.InstanceStateJSON
 	decoder.Decode(&out)
 	assert.Equal(t, 200, response.Code)
 	assert.Equal(t, "success", out.Status)


### PR DESCRIPTION
This is based of off #216 - so merge the otherone first. 
In order to let any user-interface know what `intances` are currently running they need be exposed for a start - which is what this PR accomplished. 
Furthermore in order to provide finer grained features it makes sense to start getting a basic and copieable testing done.
