### PR TITLE
Instead of sending messages as single object we wrap them in a list.

### DIFF
--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -156,8 +156,7 @@ func (e *envelop) Bytes() []byte {
 func (h *Hub) broadCastTo(u *UserID, topic Topic, data interface{}) {
 	var messages []message
 	messages = append(messages, message{topic, data})
-	e := &envelop{u, messages}
-	h.broadcast <- e
+	h.broadcast <- &envelop{u, messages}
 }
 
 func (h *Hub) run() {

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -48,8 +48,8 @@ func newWebsocketClient(t *testing.T, server *httptest.Server) *websocket.Conn {
 	return wsc
 }
 
-func readOneMessage(t *testing.T, wsc *websocket.Conn) message {
-	var out message
+func readOneMessage(t *testing.T, wsc *websocket.Conn) []message {
+	var out []message
 	var err error
 
 	// This reads exactly one message that was send via the websocket
@@ -116,8 +116,10 @@ func TestServer_Start_Operator_Push_Input_Read_Websocket_Output(t *testing.T) {
 	response := getResponse(t, server, "POST", instance.URL, bytes.NewBuffer(body))
 	assert.Equal(t, 200, response.StatusCode)
 	out := readOneMessage(t, wsc)
-	assert.Equal(t, out.Topic, "Port")
-	assert.Equal(t, out.Payload, map[string]interface{}{"data": "test", "handle": instance.Handle, "isBOS": false, "isEOS": false, "port": ")output"})
+	assert.Len(t, out, 1)
+	msg := out[0]
+	assert.Equal(t, msg.Topic, "Port")
+	assert.Equal(t, msg.Payload, map[string]interface{}{"data": "test", "handle": instance.Handle, "isBOS": false, "isEOS": false, "port": ")output"})
 }
 
 func TestServer_List_Running_Instances(t *testing.T) {


### PR DESCRIPTION
This makes it easier to send multiple messages at once. For instance
when we want to collect messages before sending them off to reduce the
backpressure on the WebSocket connection.

The message structure now changes from 
```json
{
	"Topic": "Port",                                      
	"Payload": ["..."]
}
``` 
to 
```json
[{"Topic": "Port", "Payload": ["..."]}, {"...."}]