### PR TITLE
Add more parameters to makedocs in order to make it more flexible

### DIFF
--- a/cmd/makedocs/main.go
+++ b/cmd/makedocs/main.go
@@ -107,17 +107,17 @@ func main() {
 	docURL := "https://bitspark.de/slang/docs/"
 
 	flag.BoolVar(&clean, "clean", false, "Clean folders before recreation")
-	flag.BoolVar(&genIdx, "index", false, "Generate Index")
-	flag.BoolVar(&saveUrls, "save-urls", false, "Save back doc urls into stdlib")
-	flag.BoolVar(&showHelp, "-help", false, "Show this dialog")
+	flag.BoolVar(&genIdx, "index", false, "Generate a single index file")
+	flag.BoolVar(&saveUrls, "save-urls", false, "Save back doc urls into standard library")
+	flag.BoolVar(&showHelp, "help", false, "Show this dialog")
 
-	flag.StringVar(&libDir, "libdir", "missing/", "Stdlib Location")
+	flag.StringVar(&libDir, "libdir", "./", "Location of the standard library")
 
-	flag.StringVar(&idxOut, "index-target", "missing/", "Where to write the index to")
-	flag.StringVar(&idxTpl, "index-template", "missing/", "Index template")
+	flag.StringVar(&idxOut, "index-target", "./", "Where to write the index to")
+	flag.StringVar(&idxTpl, "index-template", "./", "Index template")
 
-	flag.StringVar(&opTpl, "operator-template", "missing/", "Operator template")
-	flag.StringVar(&opOutDir, "operator-output-dir", "missing/", "Where to write the operators to")
+	flag.StringVar(&opTpl, "operator-template", "./", "Operator template")
+	flag.StringVar(&opOutDir, "operator-output-dir", "./", "Where to write the operators to")
 	flag.StringVar(&opExt, "operator-ext", "json", "What extension should the files have")
 	flag.Parse()
 

--- a/cmd/makedocs/main.go
+++ b/cmd/makedocs/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/url"
@@ -73,40 +75,87 @@ type OperatorInfo struct {
 type DocGenerator struct {
 	libDir         string
 	docOpDir       string
-	docTagDir      string
 	docIndexPath   string
 	docOpURL       *url.URL
-	docTagURL      *url.URL
 	opTmpl         *template.Template
-	tagTmpl        *template.Template
-	indexTmpl      *template.Template
 	operatorInfos  map[string]*OperatorInfo
 	tagInfos       map[string]*TagInfo
 	slugs          map[string]*OperatorInfo
 	generatedInfos []*OperatorInfo
 }
 
+var clean bool
+var genIdx bool
+var saveUrls bool
+var showHelp bool
+
+var libDir string
+
+var opTpl string
+var opExt string
+var opOutDir string
+
+var idxTpl string
+var idxOut string
+
+var Usage = func() {
+	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+	flag.PrintDefaults()
+}
+
 func main() {
-	libDir := "C:/Users/julia_000/Go/src/slang-lib/slang"
-	docDir := "C:/Bitspark/bitspark-www/html/pages/slang/docs/"
-	tplDir := "C:/Bitspark/bitspark-www/templates/"
 	docURL := "https://bitspark.de/slang/docs/"
 
-	dg := makeDocumentGenerator(libDir, docDir, tplDir, docURL)
+	flag.BoolVar(&clean, "clean", false, "Clean folders before recreation")
+	flag.BoolVar(&genIdx, "index", false, "Generate Index")
+	flag.BoolVar(&saveUrls, "save-urls", false, "Save back doc urls into stdlib")
+	flag.BoolVar(&showHelp, "-help", false, "Show this dialog")
 
-	dg.init()
+	flag.StringVar(&libDir, "libdir", "missing/", "Stdlib Location")
+
+	flag.StringVar(&idxOut, "index-target", "missing/", "Where to write the index to")
+	flag.StringVar(&idxTpl, "index-template", "missing/", "Index template")
+
+	flag.StringVar(&opTpl, "operator-template", "missing/", "Operator template")
+	flag.StringVar(&opOutDir, "operator-output-dir", "missing/", "Where to write the operators to")
+	flag.StringVar(&opExt, "operator-ext", "json", "What extension should the files have")
+	flag.Parse()
+
+	if showHelp {
+		Usage()
+		os.Exit(0)
+	}
+
+	dg := makeDocumentGenerator(libDir, idxOut, opTpl, opOutDir, docURL)
+	if clean {
+		dg.clean()
+	}
+
 	dg.collect(true)
 	dg.contents()
 	dg.usage()
-	dg.generateOperatorDocs()
-	dg.prepareTags()
-	// dg.generateTagDocs()
-	dg.generateIndex()
-	dg.saveURLs()
+	dg.generateOperatorDocs(opExt)
+
+	if genIdx {
+		bytesIndex, err := ioutil.ReadFile(idxTpl)
+		if err != nil {
+			panic(err)
+		}
+		indexTmpl, err := template.New("DocIndex").Delims("[[", "]]").Parse(string(bytesIndex))
+		if err != nil {
+			panic(err)
+		}
+
+		dg.generateIndex(*indexTmpl)
+	}
+	if saveUrls {
+		dg.saveURLs()
+	}
+
 }
 
-func makeDocumentGenerator(libDir string, docDir string, tmplDir string, docURL string) DocGenerator {
-	bytesOperator, err := ioutil.ReadFile(path.Join(tmplDir, "operator.html"))
+func makeDocumentGenerator(libDir string, idxOut string, opTpl string, opOutDir string, docURL string) DocGenerator {
+	bytesOperator, err := ioutil.ReadFile(opTpl)
 	if err != nil {
 		panic(err)
 	}
@@ -115,48 +164,24 @@ func makeDocumentGenerator(libDir string, docDir string, tmplDir string, docURL 
 		panic(err)
 	}
 
-	//bytesTag, err := ioutil.ReadFile(path.Join(tmplDir, "tag.html"))
-	//if err != nil {
-	//	panic(err)
-	//}
-	//tagTmpl, err := template.New("DocTagInfo").Delims("[[", "]]").Parse(string(bytesTag))
-	//if err != nil {
-	//	panic(err)
-	//}
-
-	bytesIndex, err := ioutil.ReadFile(path.Join(tmplDir, "doc-index.html"))
-	if err != nil {
-		panic(err)
-	}
-	indexTmpl, err := template.New("DocIndex").Delims("[[", "]]").Parse(string(bytesIndex))
-	if err != nil {
-		panic(err)
-	}
-
 	docOpURL, _ := url.Parse(docURL)
 	docOpURL.Path = path.Join(docOpURL.Path, "operator")
-	docTagURL, _ := url.Parse(docURL)
-	docTagURL.Path = path.Join(docTagURL.Path, "tag")
 
 	return DocGenerator{
 		libDir:        libDir,
-		docOpDir:      path.Join(docDir, "operator"),
-		docTagDir:     path.Join(docDir, "tag"),
-		docIndexPath:  path.Join(docDir, "index.html"),
+		docOpDir:      opOutDir,
+		docIndexPath:  idxOut,
 		docOpURL:      docOpURL,
-		docTagURL:     docTagURL,
 		opTmpl:        opTmpl,
-		indexTmpl:     indexTmpl,
 		slugs:         make(map[string]*OperatorInfo),
 		tagInfos:      make(map[string]*TagInfo),
 		operatorInfos: make(map[string]*OperatorInfo),
 	}
 }
 
-func (dg *DocGenerator) init() {
+func (dg *DocGenerator) clean() {
 	os.Remove(dg.docIndexPath)
 	os.RemoveAll(dg.docOpDir)
-	os.RemoveAll(dg.docTagDir)
 }
 
 func (dg *DocGenerator) collect(strict bool) {
@@ -371,19 +396,19 @@ func (dg *DocGenerator) usage() {
 	}
 }
 
-func (dg *DocGenerator) generateOperatorDocs() {
+func (dg *DocGenerator) generateOperatorDocs(extension string) {
 	log.Println("Begin generating operator docs")
 
 	if len(dg.operatorInfos) == 0 {
 		panic("No operators found")
 	}
 
-	os.MkdirAll(dg.docOpDir, os.ModeDir)
+	//os.MkdirAll(dg.docOpDir, os.ModeDir)
 
 	generated := 0
 
 	for _, opInfo := range dg.operatorInfos {
-		file, err := os.Create(path.Join(dg.docOpDir, opInfo.Slug+".html"))
+		file, err := os.Create(path.Join(dg.docOpDir, opInfo.Slug+"."+extension))
 		if err != nil {
 			panic(err)
 		}
@@ -401,54 +426,7 @@ func (dg *DocGenerator) generateOperatorDocs() {
 	log.Printf("Generated %d operator doc files\n", generated)
 }
 
-func (dg *DocGenerator) prepareTags() {
-	for _, tagInfo := range dg.tagInfos {
-		// Remove JSON and tags to avoid recursion
-		for i, op := range tagInfo.operators {
-			opCpy := &OperatorInfo{}
-			*opCpy = *op
-			opCpy.OperatorContentJSON = ""
-			opCpy.OperatorsUsingJSON = ""
-			opCpy.OperatorDefinitions = nil
-			tagInfo.operators[i] = opCpy
-		}
-
-		buf := new(bytes.Buffer)
-		json.NewEncoder(buf).Encode(tagInfo.operators)
-		buf.Truncate(buf.Len() - 1)
-		tagInfo.OperatorsJSON = buf.String()
-	}
-}
-
-func (dg *DocGenerator) generateTagDocs() {
-	log.Println("Begin generating tag docs")
-
-	if len(dg.tagInfos) == 0 {
-		panic("No tags found")
-	}
-
-	os.MkdirAll(dg.docTagDir, os.ModeDir)
-
-	generated := 0
-
-	for _, tagInfo := range dg.tagInfos {
-		file, err := os.Create(path.Join(dg.docTagDir, tagInfo.Slug+".html"))
-		if err != nil {
-			panic(err)
-		}
-		err = dg.tagTmpl.Execute(file, tagInfo)
-		if err != nil {
-			panic(err)
-		}
-		file.Close()
-
-		generated++
-	}
-
-	log.Printf("Generated %d operator doc files\n", generated)
-}
-
-func (dg *DocGenerator) generateIndex() {
+func (dg *DocGenerator) generateIndex(indexTmpl template.Template) {
 	log.Println("Begin generating doc index")
 
 	if len(dg.tagInfos) == 0 {
@@ -461,7 +439,7 @@ func (dg *DocGenerator) generateIndex() {
 	if err != nil {
 		panic(err)
 	}
-	err = dg.indexTmpl.Execute(file, struct {
+	err = indexTmpl.Execute(file, struct {
 		Total int
 		Tags  map[string]*TagInfo
 	}{len(dg.generatedInfos), dg.tagInfos})


### PR DESCRIPTION
This PR makes generating the docs more flexible through parameterization, which of course is only a poor man's solution to an underlying problem. We now need to have different representations of the documentation for different systems and frontends. I also removed generating the tags as it was not used in the original version anyways.

Now makedocs support various parameters which help generating all sorts of outcomes.
```bash
>> go run cmd/makedocs/main.go  --help
Usage of /var/folders/0t/33fk6whx0q3fj6h77gw_nq9w0000gn/T/go-build074470256/b001/exe/main:
  -clean
        Clean folders before recreation
  -help
        Show this dialog
  -index
        Generate a single index file
  -index-target string
        Where to write the index to (default "./")
  -index-template string
        Index template (default "./")
  -libdir string
        Location of the standard library (default "./")
  -operator-ext string
        What extension should the files have (default "json")
  -operator-output-dir string
        Where to write the operators to (default "./")
  -operator-template string
        Operator template (default "./")
  -save-urls
        Save back doc urls into standard library
```