### PR TITLE
Allow running slangd in safe and unsafe mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Go Slangd Unsafe",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}/cmd/slangd",
+            "args": ["--only-daemon", "--without-ui"]
+        },
+        {
+            "name": "Go Slangd Safe",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}/cmd/slangd",
+            "args": ["--only-daemon", "--without-ui", "--safe"]
+        },
+    ]
+}

--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Bitspark/slang/pkg/elem"
 	"github.com/Bitspark/slang/pkg/env"
 	"github.com/Bitspark/slang/pkg/storage"
 
@@ -31,12 +32,18 @@ var (
 var onlyDaemon bool
 var skipChecks bool
 var withoutUI bool
+var safeMode bool
 
 func main() {
+	flag.BoolVar(&safeMode, "safe", false, "Only support safe operator. Unsafe operators are handled as not existing.")
 	flag.BoolVar(&onlyDaemon, "only-daemon", false, "Don't automatically open UI")
 	flag.BoolVar(&skipChecks, "skip-checks", false, "Skip checking and updating UI and Lib")
 	flag.BoolVar(&withoutUI, "without-ui", false, "Do not serve the UI found in SLANG_UI")
 	flag.Parse()
+
+	// init elementary operators in proper mode (safe mode oder unsafe mode)
+	elem.SetSafeMode(safeMode)
+	elem.Init()
 
 	buildTime, _ := strconv.ParseInt(BuildTime, 10, 64)
 	if buildTime != 0 {

--- a/cmd/slangd/main.go
+++ b/cmd/slangd/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.Parse()
 
 	// init elementary operators in proper mode (safe mode oder unsafe mode)
-	elem.SetSafeMode(safeMode)
+	elem.SafeMode = safeMode
 	elem.Init()
 
 	buildTime, _ := strconv.ParseInt(BuildTime, 10, 64)

--- a/pkg/elem/control_iterate.go
+++ b/pkg/elem/control_iterate.go
@@ -9,6 +9,7 @@ import (
 
 var controlIterateId = uuid.MustParse("e58624d4-5568-40d3-8b77-ab792ef620f1")
 var controlIterateCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: controlIterateId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/control_loop.go
+++ b/pkg/elem/control_loop.go
@@ -7,6 +7,7 @@ import (
 
 var controlLoopId = uuid.MustParse("0b8a1592-1368-44bc-92d5-692acc78b1d3")
 var controlLoopCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: controlLoopId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/control_reduce.go
+++ b/pkg/elem/control_reduce.go
@@ -9,6 +9,7 @@ import (
 
 var controlReduceId = uuid.MustParse("b95e6da8-9770-4a04-a73d-cdfe2081870f")
 var controlReduceCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: controlReduceId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/control_semaphore_p.go
+++ b/pkg/elem/control_semaphore_p.go
@@ -29,6 +29,7 @@ func getSemaphoreStore(semaphore string) *semaphoreStore {
 
 var controlSemaphorePId = uuid.MustParse("199f14c3-3e25-4813-aaba-7ec7fa3d94e2")
 var controlSemaphorePCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: controlSemaphorePId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/control_semaphore_v.go
+++ b/pkg/elem/control_semaphore_v.go
@@ -7,6 +7,7 @@ import (
 
 var controlSemaphoreVId = uuid.MustParse("dc9b35a3-bd0e-4ca3-99df-4e2689ea5097")
 var controlSemaphoreVCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: controlSemaphoreVId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/control_split.go
+++ b/pkg/elem/control_split.go
@@ -7,6 +7,7 @@ import (
 
 var controlSplitId = uuid.MustParse("fed72b41-2584-424c-8213-1978410ccab6")
 var controlSplitCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: controlSplitId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/control_switch.go
+++ b/pkg/elem/control_switch.go
@@ -9,6 +9,7 @@ import (
 
 var controlSwitchId = uuid.MustParse("cd6fc5c8-5b64-4b1a-9885-59ede141b398")
 var controlSwitchCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: controlSwitchId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/control_take.go
+++ b/pkg/elem/control_take.go
@@ -7,6 +7,7 @@ import (
 
 var controlTakeId = uuid.MustParse("9bebc4bf-d512-4944-bcb1-5b2c3d5b5471")
 var controlTakeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: controlTakeId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/data_convert.go
+++ b/pkg/elem/data_convert.go
@@ -50,6 +50,7 @@ func stringToBool(value string) bool {
 
 var dataConvertId = uuid.MustParse("d1191456-3583-4eaf-8ec1-e486c3818c60")
 var dataConvertCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: dataConvertId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/data_evaluate.go
+++ b/pkg/elem/data_evaluate.go
@@ -85,6 +85,7 @@ func newEvaluableExpression(expression string) (*EvaluableExpression, error) {
 
 var dataEvaluateId = uuid.MustParse("37ccdc28-67b0-4bb1-8591-4e0e813e3ec1")
 var dataEvaluateCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: dataEvaluateId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/data_uuid.go
+++ b/pkg/elem/data_uuid.go
@@ -7,6 +7,7 @@ import (
 
 var dataUUIDId = uuid.MustParse("a83bf9b2-cf1b-4b14-94c2-ea04d5cf70c0")
 var dataUUIDCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: dataUUIDId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/data_value.go
+++ b/pkg/elem/data_value.go
@@ -7,6 +7,7 @@ import (
 
 var dataValueId = uuid.MustParse("8b62495a-e482-4a3e-8020-0ab8a350ad2d")
 var dataValueCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: dataValueId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/data_variable_get.go
+++ b/pkg/elem/data_variable_get.go
@@ -9,6 +9,7 @@ import (
 
 var dataVariableGetId = uuid.MustParse("b8771c73-cddf-4eb1-a10c-bf78c2552efe")
 var dataVariableGetCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: dataVariableGetId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/data_variable_set.go
+++ b/pkg/elem/data_variable_set.go
@@ -30,6 +30,7 @@ func getVariableStore(store string) *variableStore {
 
 var dataVariableSetId = uuid.MustParse("3be41b5b-5a43-4f94-a7ae-7f0bacc4ae77")
 var dataVariableSetCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: dataVariableSetId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_execute.go
+++ b/pkg/elem/database_execute.go
@@ -10,6 +10,7 @@ import (
 
 var databaseExecuteId = uuid.MustParse("e5abeb01-3aad-47f3-a753-789a9fff0d50")
 var databaseExecuteCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: databaseExecuteId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_kafka_subscribe.go
+++ b/pkg/elem/database_kafka_subscribe.go
@@ -11,6 +11,7 @@ import (
 
 var databaseKafkaSubscribeId = uuid.MustParse("b6cb78ca-bbfd-475e-a11f-3593ce295e3c")
 var databaseKafkaSubscribeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: databaseKafkaSubscribeId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_memory_read.go
+++ b/pkg/elem/database_memory_read.go
@@ -30,6 +30,7 @@ func getMemoryStore(store string) *memoryStore {
 
 var databaseMemoryReadId = uuid.MustParse("2fcd32f5-c83c-4fff-9ac2-ccd6d02139fa")
 var databaseMemoryReadCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: databaseMemoryReadId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_memory_write.go
+++ b/pkg/elem/database_memory_write.go
@@ -7,6 +7,7 @@ import (
 
 var databaseMemoryWriteId = uuid.MustParse("78e92496-dd73-4422-bcd0-691fa549dccd")
 var databaseMemoryWriteCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: databaseMemoryWriteId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_query.go
+++ b/pkg/elem/database_query.go
@@ -11,6 +11,7 @@ import (
 )
 
 var databaseQueryCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("ce3a3e0e-d579-4712-8573-713a645c2271"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_redis_get.go
+++ b/pkg/elem/database_redis_get.go
@@ -7,6 +7,7 @@ import (
 )
 
 var databaseRedisGetCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("362482c1-2021-4e5c-9463-b580a6c1967e"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_redis_hget.go
+++ b/pkg/elem/database_redis_hget.go
@@ -7,6 +7,7 @@ import (
 )
 
 var databaseRedisHGetCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("4b946e4a-e26b-45c7-9759-c60bd57d190d"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_redis_hincrby.go
+++ b/pkg/elem/database_redis_hincrby.go
@@ -7,6 +7,7 @@ import (
 )
 
 var databaseRedisHIncrByCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("8d9e4c6e-20a2-44b1-8d51-ed98f4d3b4d8"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_redis_hset.go
+++ b/pkg/elem/database_redis_hset.go
@@ -7,6 +7,7 @@ import (
 )
 
 var databaseRedisHSetCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("a6b45f70-e20c-40a5-ac39-c00068d10c81"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_redis_lpush.go
+++ b/pkg/elem/database_redis_lpush.go
@@ -7,6 +7,7 @@ import (
 )
 
 var databaseRedisLPushCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("8f8a095c-9274-4d39-96d9-3ef463659426"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_redis_set.go
+++ b/pkg/elem/database_redis_set.go
@@ -9,6 +9,7 @@ import (
 )
 
 var databaseRedisSetCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("cdbf3e0d-1ce0-4565-9df6-d0e829c730e5"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/database_redis_subscribe.go
+++ b/pkg/elem/database_redis_subscribe.go
@@ -7,6 +7,7 @@ import (
 )
 
 var databaseRedisSubscribeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("eb3fd302-f6b0-4c2a-b353-ff0a01e49d09"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/encoding_csv_read.go
+++ b/pkg/elem/encoding_csv_read.go
@@ -12,6 +12,7 @@ import (
 
 var encodingCSVReadId = uuid.MustParse("77d60459-f8b5-4f4b-b293-740164c49a82")
 var encodingCSVReadCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: encodingCSVReadId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/encoding_csv_write.go
+++ b/pkg/elem/encoding_csv_write.go
@@ -10,6 +10,7 @@ import (
 
 var encodingCSVWriteId = uuid.MustParse("fdd1e8e5-6959-4511-bf44-54c1bcbebc12")
 var encodingCSVWriteCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: encodingCSVWriteId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/encoding_json_path.go
+++ b/pkg/elem/encoding_json_path.go
@@ -8,6 +8,7 @@ import (
 
 var encodingJSONPathId = uuid.MustParse("89571f57-4aad-4bb8-9d03-573343ff1202")
 var encodingJSONPathCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: encodingJSONPathId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/encoding_json_read.go
+++ b/pkg/elem/encoding_json_read.go
@@ -9,6 +9,7 @@ import (
 
 var encodingJSONReadId = uuid.MustParse("b79b019f-5efe-4012-9a1d-1f61549ede25")
 var encodingJSONReadCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: encodingJSONReadId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/encoding_json_write.go
+++ b/pkg/elem/encoding_json_write.go
@@ -9,6 +9,7 @@ import (
 
 var encodingJSONWriteId = uuid.MustParse("d4aabe2d-dee7-409f-b2bb-713ebc836672")
 var encodingJSONWriteCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: encodingJSONWriteId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/encoding_url_write.go
+++ b/pkg/elem/encoding_url_write.go
@@ -9,6 +9,7 @@ import (
 )
 
 var encodingURLWriteCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("702a2036-a1cc-4783-8b83-b18494c5e9f1"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/encoding_xlsx_read.go
+++ b/pkg/elem/encoding_xlsx_read.go
@@ -7,6 +7,7 @@ import (
 )
 
 var encodingXLSXReadCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("69db81cf-2a24-4470-863f-ceffaeb8b246"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_append.go
+++ b/pkg/elem/files_append.go
@@ -9,7 +9,7 @@ import (
 )
 
 var filesAppendCfg = &builtinConfig{
-	safe: true,
+	safe: false,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("e49369c2-eac2-4dc7-9a6d-b635ae1654f9"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_append.go
+++ b/pkg/elem/files_append.go
@@ -9,6 +9,7 @@ import (
 )
 
 var filesAppendCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("e49369c2-eac2-4dc7-9a6d-b635ae1654f9"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_read.go
+++ b/pkg/elem/files_read.go
@@ -12,6 +12,7 @@ import (
 
 var filesReadId = uuid.MustParse("f7eecf2c-6504-478f-b2fa-809bec71463c")
 var filesReadCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: filesReadId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_read_lines.go
+++ b/pkg/elem/files_read_lines.go
@@ -10,6 +10,7 @@ import (
 )
 
 var filesReadLinesCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("6124cd6b-5c23-4e17-a714-458d0f8ac1a7"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_write.go
+++ b/pkg/elem/files_write.go
@@ -10,6 +10,7 @@ import (
 )
 
 var filesWriteCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("9b61597d-cfbc-42d1-9620-210081244ba1"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_write.go
+++ b/pkg/elem/files_write.go
@@ -10,7 +10,7 @@ import (
 )
 
 var filesWriteCfg = &builtinConfig{
-	safe: true,
+	safe: false,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("9b61597d-cfbc-42d1-9620-210081244ba1"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_zip_pack.go
+++ b/pkg/elem/files_zip_pack.go
@@ -9,7 +9,7 @@ import (
 )
 
 var filesZIPPackCfg = &builtinConfig{
-	safe: true,
+	safe: false,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("dc5325bc-a816-47c8-8a8a-f741497459f7"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_zip_pack.go
+++ b/pkg/elem/files_zip_pack.go
@@ -9,6 +9,7 @@ import (
 )
 
 var filesZIPPackCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("dc5325bc-a816-47c8-8a8a-f741497459f7"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/files_zip_unpack.go
+++ b/pkg/elem/files_zip_unpack.go
@@ -9,6 +9,7 @@ import (
 )
 
 var filesZIPUnpackCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("04714d4a-1d5d-4b68-b614-524dd4662ef4"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/image_decode.go
+++ b/pkg/elem/image_decode.go
@@ -9,6 +9,7 @@ import (
 )
 
 var imageDecodeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("4b082c52-9a99-472f-9277-f5ca9651dbfb"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/image_encode.go
+++ b/pkg/elem/image_encode.go
@@ -16,6 +16,7 @@ import (
 )
 
 var imageEncodeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("bd4475af-795b-4be8-9e57-9fec9444e028"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/manager.go
+++ b/pkg/elem/manager.go
@@ -13,6 +13,7 @@ type builtinConfig struct {
 	opConnFunc core.CFunc
 	opFunc     core.OFunc
 	blueprint  core.Blueprint
+	safe       bool
 }
 
 var cfgs map[uuid.UUID]*builtinConfig

--- a/pkg/elem/manager.go
+++ b/pkg/elem/manager.go
@@ -16,6 +16,10 @@ type builtinConfig struct {
 	safe       bool
 }
 
+// easy way to control registering of unsafe elementary operators
+// set this global to true if slang should run in safe mode
+var SAFE bool = false
+
 var cfgs map[uuid.UUID]*builtinConfig
 var name2Id map[string]uuid.UUID
 
@@ -55,6 +59,12 @@ func IsRegistered(id uuid.UUID) bool {
 }
 
 func Register(cfg *builtinConfig) {
+	if SAFE && SAFE != cfg.safe {
+		// slang run in safe mode,
+		// unsafe elementary operators cannot be registered
+		return
+	}
+
 	cfg.blueprint.Elementary = cfg.blueprint.Id
 
 	id := cfg.blueprint.Id

--- a/pkg/elem/manager.go
+++ b/pkg/elem/manager.go
@@ -16,9 +16,7 @@ type builtinConfig struct {
 	safe       bool
 }
 
-// easy way to control registering of unsafe elementary operators
-// set this global to true if slang should run in safe mode
-var SAFE bool = false
+var SAFE_MODE bool = false
 
 var cfgs map[uuid.UUID]*builtinConfig
 var name2Id map[string]uuid.UUID
@@ -59,7 +57,7 @@ func IsRegistered(id uuid.UUID) bool {
 }
 
 func Register(cfg *builtinConfig) {
-	if SAFE && SAFE != cfg.safe {
+	if SAFE_MODE && SAFE_MODE != cfg.safe {
 		// slang run in safe mode,
 		// unsafe elementary operators cannot be registered
 		return
@@ -76,7 +74,11 @@ func GetBuiltinIds() []uuid.UUID {
 	return funk.Keys(cfgs).([]uuid.UUID)
 }
 
-func init() {
+func SetSafeMode(safe bool) {
+	SAFE_MODE = safe
+}
+
+func Init() {
 	cfgs = make(map[uuid.UUID]*builtinConfig)
 	name2Id = make(map[string]uuid.UUID)
 

--- a/pkg/elem/manager.go
+++ b/pkg/elem/manager.go
@@ -16,7 +16,7 @@ type builtinConfig struct {
 	safe       bool
 }
 
-var SAFE_MODE bool = false
+var SafeMode bool
 
 var cfgs map[uuid.UUID]*builtinConfig
 var name2Id map[string]uuid.UUID
@@ -57,7 +57,7 @@ func IsRegistered(id uuid.UUID) bool {
 }
 
 func Register(cfg *builtinConfig) {
-	if SAFE_MODE && SAFE_MODE != cfg.safe {
+	if SafeMode && SafeMode != cfg.safe {
 		// slang run in safe mode,
 		// unsafe elementary operators cannot be registered
 		return
@@ -72,10 +72,6 @@ func Register(cfg *builtinConfig) {
 
 func GetBuiltinIds() []uuid.UUID {
 	return funk.Keys(cfgs).([]uuid.UUID)
-}
-
-func SetSafeMode(safe bool) {
-	SAFE_MODE = safe
 }
 
 func Init() {
@@ -187,6 +183,16 @@ func Init() {
 func getBuiltinCfg(id uuid.UUID) *builtinConfig {
 	c, _ := cfgs[id]
 	return c
+}
+
+func getBuiltinCfgErr(id uuid.UUID) (*builtinConfig, error) {
+	cfg, ok := cfgs[id]
+
+	if !ok {
+		return nil, errors.New("builtin operator not found")
+	}
+
+	return cfg, nil
 }
 
 // Mainly for testing

--- a/pkg/elem/meta_store.go
+++ b/pkg/elem/meta_store.go
@@ -114,6 +114,7 @@ func (s store) resetIndexes() {
 
 var metaStoreId = uuid.MustParse("cf20bcec-2028-45b4-a00c-0ce348c381c4")
 var metaStoreCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: metaStoreId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/net_http_client.go
+++ b/pkg/elem/net_http_client.go
@@ -10,6 +10,7 @@ import (
 )
 
 var netHTTPClientCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("f7f5907d-758b-4892-8a3e-ae86b877b869"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/net_http_server.go
+++ b/pkg/elem/net_http_server.go
@@ -82,6 +82,7 @@ func (r *requestHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 
 var netHTTPServerId = uuid.MustParse("241cc7ef-c6d6-49c1-8729-c5e3c0be8188")
 var netHTTPServerCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: netHTTPServerId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/net_mqtt_publish.go
+++ b/pkg/elem/net_mqtt_publish.go
@@ -9,6 +9,7 @@ import (
 )
 
 var netMQTTPublishCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("c6b5bef6-e93e-4bc1-8ded-49c90919f39d"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/net_mqtt_subscribe.go
+++ b/pkg/elem/net_mqtt_subscribe.go
@@ -9,6 +9,7 @@ import (
 )
 
 var netMQTTSubscribeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("fd51e295-3483-4558-9b26-8c16d579c4ef"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/net_send_email.go
+++ b/pkg/elem/net_send_email.go
@@ -12,6 +12,7 @@ import (
 )
 
 var netSendEmailCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("741b8a21-0b6d-40e5-a281-b179a49e9030"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/rand_range.go
+++ b/pkg/elem/rand_range.go
@@ -10,6 +10,7 @@ import (
 
 var randRangeId = uuid.MustParse("30e3a788-b5ec-4c0f-9338-4a78fe63bd9f")
 var randRangeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: randRangeId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/shell_execute.go
+++ b/pkg/elem/shell_execute.go
@@ -8,7 +8,7 @@ import (
 )
 
 var shellExecuteCfg = &builtinConfig{
-	safe: true,
+	safe: false,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("13cbad40-da00-40d7-bdcd-981b14ec346b"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/shell_execute.go
+++ b/pkg/elem/shell_execute.go
@@ -8,6 +8,7 @@ import (
 )
 
 var shellExecuteCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("13cbad40-da00-40d7-bdcd-981b14ec346b"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_concatenate.go
+++ b/pkg/elem/stream_concatenate.go
@@ -6,6 +6,7 @@ import (
 )
 
 var streamConcatenateCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("fb174c53-80bd-4e29-955a-aafe33ebfb30"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_distinct.go
+++ b/pkg/elem/stream_distinct.go
@@ -8,6 +8,7 @@ import (
 )
 
 var streamDistinctCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("d8914bae-2878-46f3-b468-9e7faea7a463"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_map_access.go
+++ b/pkg/elem/stream_map_access.go
@@ -9,6 +9,7 @@ import (
 
 var streamMapAccessId = uuid.MustParse("618c4007-70fc-44ac-9443-184df77ab730")
 var streamMapAccessCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: streamMapAccessId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_map_to_stream.go
+++ b/pkg/elem/stream_map_to_stream.go
@@ -7,6 +7,7 @@ import (
 
 var streamMapToStreamId = uuid.MustParse("d099a1cd-69eb-43a2-b95b-239612c457fc")
 var streamMapToStreamCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: streamMapToStreamId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_parallelize.go
+++ b/pkg/elem/stream_parallelize.go
@@ -10,6 +10,7 @@ import (
 
 var streamParallelizeId = uuid.MustParse("b8428777-7667-4012-b76a-a5b7f4d1e433")
 var streamParallelizeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: streamParallelizeId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_serialize.go
+++ b/pkg/elem/stream_serialize.go
@@ -9,6 +9,7 @@ import (
 )
 
 var streamSerializeCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("13257172-b05d-497c-be23-da7c86577c1e"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_slice.go
+++ b/pkg/elem/stream_slice.go
@@ -6,6 +6,7 @@ import (
 )
 
 var streamSliceCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("2471a7aa-c5b9-4392-b23f-d0c7bcdb3f39"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_stream_to_map.go
+++ b/pkg/elem/stream_stream_to_map.go
@@ -6,6 +6,7 @@ import (
 )
 
 var streamStreamToMapCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("42d0f961-4ce0-4a20-b1b0-3da46396ae66"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_transform.go
+++ b/pkg/elem/stream_transform.go
@@ -6,6 +6,7 @@ import (
 )
 
 var streamTransformCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("dce082cb-7272-4e85-b4fa-740778e8ba8d"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_window.go
+++ b/pkg/elem/stream_window.go
@@ -7,6 +7,7 @@ import (
 
 var streamWindowId = uuid.MustParse("5b704038-9617-454a-b7a1-2091277cff69")
 var streamWindowCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: streamWindowId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_window_collect.go
+++ b/pkg/elem/stream_window_collect.go
@@ -29,6 +29,7 @@ func getWindowStore(store string) *windowStore {
 }
 
 var streamWindowCollectCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("14f5de1a-5e38-4f9c-a625-eff7a572078c"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/stream_window_release.go
+++ b/pkg/elem/stream_window_release.go
@@ -6,6 +6,7 @@ import (
 )
 
 var streamWindowReleaseCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("47b3f097-2043-42c6-aad5-0cfdb9004aef"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/string_beginswith.go
+++ b/pkg/elem/string_beginswith.go
@@ -8,6 +8,7 @@ import (
 )
 
 var stringBeginswithCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("9f274995-2726-4513-ac7c-f15ac7b68720"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/string_contains.go
+++ b/pkg/elem/string_contains.go
@@ -8,6 +8,7 @@ import (
 )
 
 var stringContainsCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("8a01dfe3-5dcf-4f40-9e54-f5b168148d2a"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/string_endswith.go
+++ b/pkg/elem/string_endswith.go
@@ -8,6 +8,7 @@ import (
 )
 
 var stringEndswithCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("db8b1677-baaf-4072-8047-0359cd68be9e"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/string_format.go
+++ b/pkg/elem/string_format.go
@@ -8,6 +8,7 @@ import (
 )
 
 var stringFormatCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("21dbddf2-2d07-494e-8950-3ac0224a3ff5"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/string_split.go
+++ b/pkg/elem/string_split.go
@@ -8,6 +8,7 @@ import (
 )
 
 var stringSplitCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("c02bc7ad-65e5-4a43-a2a3-7d86b109915d"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/string_template.go
+++ b/pkg/elem/string_template.go
@@ -10,6 +10,7 @@ import (
 
 var stringTemplateId = uuid.MustParse("3c39f999-b5c2-490d-aed1-19149d228b04")
 var stringTemplateCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: stringTemplateId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/system_log.go
+++ b/pkg/elem/system_log.go
@@ -9,6 +9,7 @@ import (
 
 var systemLogId = uuid.MustParse("8f9c02df-da41-4266-b486-0c22173a6383")
 var systemLogCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: systemLogId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/time_crontab.go
+++ b/pkg/elem/time_crontab.go
@@ -7,6 +7,7 @@ import (
 )
 
 var timeCrontabCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("60b849fd-ca5a-4206-8312-996e4e3f6c31"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/time_date.go
+++ b/pkg/elem/time_date.go
@@ -23,6 +23,7 @@ func parseDate(dateStr string) (time.Time, error) {
 }
 
 var timeParseDateCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("2a9da2d5-2684-4d2f-8a37-9560d0f2de29"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/time_date_now.go
+++ b/pkg/elem/time_date_now.go
@@ -8,6 +8,7 @@ import (
 )
 
 var timeDateNowCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("808c7846-db9f-43ee-989b-37a08ce7e70d"),
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/time_delay.go
+++ b/pkg/elem/time_delay.go
@@ -9,6 +9,7 @@ import (
 
 var timeDelayId = uuid.MustParse("7d61b83a-9aa2-4875-9c21-1e11f6adbfae")
 var timeDelayCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: timeDelayId,
 		Meta: core.BlueprintMetaDef{

--- a/pkg/elem/time_unix.go
+++ b/pkg/elem/time_unix.go
@@ -8,6 +8,7 @@ import (
 )
 
 var timeUNIXMillisCfg = &builtinConfig{
+	safe: true,
 	blueprint: core.Blueprint{
 		Id: uuid.MustParse("d58b458e-8b3a-49f3-a6e9-45e737354937"),
 		Meta: core.BlueprintMetaDef{


### PR DESCRIPTION
Running operators via slangd must also be possible without side effects on the host machine. For this I introduce an `--safe` argument which allows running slangd in safe mode. 

Current implementation:
On safe mode all elementary operators with possible side effects on host machine (e.g. exec shell commands) won't be registered and treated as not existing.
Downside: 
You cannot view and edit blueprints containing unsafe elementary operators.